### PR TITLE
Workaround for issue with shapely

### DIFF
--- a/ai-ml/vertex-ai-pipelines-template-blog/google_cloud_pipeline_template.ipynb
+++ b/ai-ml/vertex-ai-pipelines-template-blog/google_cloud_pipeline_template.ipynb
@@ -191,7 +191,7 @@
     "if IS_WORKBENCH_NOTEBOOK:\n",
     "    USER_FLAG = \"--user\"\n",
     "\n",
-    "! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} -q\n",
+    "! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} \"shapely<2\" -q\n",
     "! pip3 install -U google-cloud-storage {USER_FLAG} -q\n",
     "! pip3 install {USER_FLAG} kfp==2.0.0b1 --upgrade -q"
    ]


### PR DESCRIPTION
Correcting:

! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} -q

with:

! pip3 install --upgrade google-cloud-aiplatform {USER_FLAG} "shapely<2" -q

to workaround the following issue:

https://github.com/googleapis/python-aiplatform/issues/1852

also documented here:

https://stackoverflow.com/questions/74831594/cannot-import-name-wkbwriter-from-shapely-geos-when-import-google-cloud-ai-p

Without this workaround, the line "import google.cloud.aiplatform as vertex_ai" fails.