### PR TITLE
Update chat.tsx

### DIFF
--- a/infrastructure/cymbal-toy-store/frontend/src/app/chat.tsx
+++ b/infrastructure/cymbal-toy-store/frontend/src/app/chat.tsx
@@ -122,6 +122,10 @@ export default function Chat({
               <Image alt="send" src="/cart_add.svg" height="30" width="30" />
               Add to cart
             </button>
+
+            <a href="https://toys-uxu5wi2jpa-uc.a.run.app" target="_blank">Toys like this!
+            </a>
+            
           </div>
         )}
         <div ref={messagesEndRef}></div>


### PR DESCRIPTION
Hi @gotochkin 
I know this is a last min request. I was thinking may be just for a couple of days, could we include this URL in the chat - to enable users to snap a toy placed in the demo booth and copy the description to the chat input. Kindly let me know if this is ok to just merge this PR:

   <a href="https://toys-uxu5wi2jpa-uc.a.run.app" target="_blank">Toys like this: Click and Copy!
            </a>