### PR TITLE
Add contributing steps and missing meta files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# How to Contribute
+
+This repository is for code that supports talks and other activities the Google Cloud Developer Relations team engages in. As such, it is **not** open to external contributions.
+
+## Required Steps
+
+1. Confirm that your demo should indeed be hosted here by reading [go/cloud-devrel-code-hosting](go/cloud-devrel-code-hosting).
+1. Read and understand the OSS patching guidelines at [go/oss-patching](go/oss-patching), which includes having adequate license headers.
+1. Read and understand this repo's privacy design at [go/devrel-demos-repo-privacy](go/devrel-demos-repo-privacy).
+1. Create a sub-directory under one of the already existing root directories with your demo's name, for example `/ai-ml/cloud-next-2025-awesome-demo-name`. Do not expand the directory structure further than `/category/demo-name/**`.
+1. Open a PR with your changes and wait for a CODEOWNERS to review and merge.
+
+## Community Guidelines
+
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/).

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+To report a security issue, please use [g.co/vulnz](https://g.co/vulnz).
+
+The Google Security Team will respond within 5 working days of your report on g.co/vulnz.
+
+We use g.co/vulnz for our intake, and do coordination and disclosure here using GitHub Security Advisory to privately discuss and fix the issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,0 @@
-# How to Contribute
-
-This repository is for code that supports talks and other activities the Google Cloud Developer Relations team engages in. As such, it is not open to external contributions. 
-
-## Community Guidelines
-
-This project follows
-[Google's Open Source Community Guidelines](https://opensource.google/conduct/).

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
-# Purpose 
+# Google Cloud DevRel Demos
 
 This repo is for code that supports talks, blogs, and other activities the Google Developer Relations team engages in. **This code is unmaintained.** 
 
-# Organization 
+## Organization
 
 This repo is organized around the primary Google Cloud Product(s) used. The categories are:
 
-* AI and Machine Learning 
-* Application Development (Serverless and Developer Tools) 
-* Containers & Kubernetes
-* Data Analytics
-* DevOps
-* Infrastructure (Compute, Databases, Storage, and Networking) 
-* Security
-* Other / Multi-product 
-* Languages 
+* [AI & Machine Learning](/ai-ml)
+* [Application Development](/app-dev) (Serverless and Developer Tools)
+* [Containers & Kubernetes](/containers)
+* [Data Analytics](/data-analytics)
+* [DevOps](/devops)
+* [Infrastructure](/infrastructure) (Compute, Databases, Storage, and Networking)
+* [Languages](/languages)
+* [Security](/security)
+* [Other & Multi-product](/security)
 
+## Contributions
 
+Due to its nature, this repo does not accept community contributions.
+
+Googlers within the Google Cloud DevRel organization can follow [the contributing guide](/.github/CONTRIBUTING.md) to provide new or updated samples.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo is organized around the primary Google Cloud Product(s) used. The cate
 * [Infrastructure](/infrastructure) (Compute, Databases, Storage, and Networking)
 * [Languages](/languages)
 * [Security](/security)
-* [Other & Multi-product](/security)
+* [Other & Multi-product](/other)
 
 ## Contributions
 


### PR DESCRIPTION
This PR:
- Add links to the root README and links to the contributing guide
- Expands the contributing guide to cover required steps
- Adds missing meta files (security, code of conduct) to match other Google org repos

Staged:
- https://github.com/GoogleCloudPlatform/devrel-demos/blob/02f3bcdc27859bad3bfce17a8d0c46bbe23f5cb6/README.md
- https://github.com/GoogleCloudPlatform/devrel-demos/blob/02f3bcdc27859bad3bfce17a8d0c46bbe23f5cb6/.github/CONTRIBUTING.md