### PR TITLE
fix(podcast): remove hardcoded project/region, lint

### DIFF
--- a/containers/podcast-assistant-mcp/.env.example
+++ b/containers/podcast-assistant-mcp/.env.example
@@ -1,11 +1,5 @@
-# Google Cloud Platform Project ID
-GCP_PROJECT_ID="your-gcp-project-id"
-
 # Google Cloud Storage bucket name
 GCS_BUCKET_NAME="your-gcs-bucket-name"
-
-# Optional: Google Cloud region
-# GCP_REGION="us-central1"
 
 # Optional: Model name
 # MODEL_NAME="gemini-2.5-flash"

--- a/containers/podcast-assistant-mcp/README.md
+++ b/containers/podcast-assistant-mcp/README.md
@@ -35,7 +35,7 @@ A Multi-tool Control Plane (MCP) server is a backend service that exposes a set 
     ```bash
     cp .env.example .env
     ```
-    **Then, open the `.env` file and add your specific configuration details for `GCP_PROJECT_ID` and `GCS_BUCKET_NAME`.**
+    **Then, open the `.env` file and add your specific configuration details for `GCS_BUCKET_NAME`.**
 
 ### Deploying to Cloud Run
 
@@ -46,7 +46,7 @@ A Multi-tool Control Plane (MCP) server is a backend service that exposes a set 
 
 2.  **Build and deploy the container image:**
     ```bash
-    gcloud run deploy podcast-assistant --no-allow-unauthenticated --source . --region us-central1 --set-env-vars="GCP_PROJECT_ID=your-gcp-project-id,GCS_BUCKET_NAME=your-gcs-bucket-name"
+    gcloud run deploy podcast-assistant --no-allow-unauthenticated --source . --region us-central1 --env-vars-file .env
     ```
 
     By using the --no-allow-unauthenticated command, we ensure that only authenticated Google Cloud users can use this MCP server.

--- a/containers/podcast-assistant-mcp/pyproject.toml
+++ b/containers/podcast-assistant-mcp/pyproject.toml
@@ -6,6 +6,5 @@ requires-python = ">=3.13"
 dependencies = [
     "fastmcp==2.12.3",
     "google-cloud-storage==3.4.1",
-    "google-genai==1.36.0",
-    "packaging==25.0",
+    "google-genai==1.36.0"
 ]

--- a/containers/podcast-assistant-mcp/server.py
+++ b/containers/podcast-assistant-mcp/server.py
@@ -1,28 +1,30 @@
 """
-    * Copyright 2025 Google LLC
-    *
-    * Licensed under the Apache License, Version 2.0 (the "License");
-    * you may not use this file except in compliance with the License.
-    * You may obtain a copy of the License at
-    *
-    *     http://www.apache.org/licenses/LICENSE-2.0
-    *
-    * Unless required by applicable law or agreed to in writing, software
-    * distributed under the License is distributed on an "AS IS" BASIS,
-    * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    * See the License for the specific language governing permissions and
-    * limitations under the License.
+* Copyright 2025 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
 """
 
 import asyncio
 import logging
 import os
-from google import genai
-from google.genai import types
-from google.cloud import storage
 from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
+import google.auth
 from fastmcp import FastMCP
+from google import genai
+from google.cloud import storage
+from google.genai import types
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(format="[%(levelname)s]: %(message)s", level=logging.INFO)
@@ -32,13 +34,15 @@ mcp = FastMCP("Podcast Asistant")
 # --- Configuration ---
 # Load configuration from environment variables.
 # This makes the code reusable and keeps sensitive info out of the source code.
-GCP_PROJECT_ID = os.getenv("GCP_PROJECT_ID")
-GCP_REGION = os.getenv("GCP_REGION", "us-central1")
 GCS_BUCKET_NAME = os.getenv("GCS_BUCKET_NAME")
 MODEL_NAME = os.getenv("MODEL_NAME", "gemini-2.5-flash")
 
-if not GCP_PROJECT_ID or not GCS_BUCKET_NAME:
-    raise ValueError("Essential environment variables GCP_PROJECT_ID and GCS_BUCKET_NAME are not set.")
+# Pull values from the environment where the service is deployed
+_, GCP_PROJECT_ID = google.auth.default()
+request = Request("http://metadata.google.internal/computeMetadata/v1/instance/region")
+request.add_header("Metadata-Flavor", "Google")
+region_metadata = urlopen(request).read()
+GCP_REGION = region_metadata.decode("utf-8").split("/")[-1]
 
 client = genai.Client(
     vertexai=True,
@@ -49,6 +53,7 @@ client = genai.Client(
 storage_client = storage.Client()
 gcs_bucket = storage_client.bucket(GCS_BUCKET_NAME)
 
+
 # --- Helper Functions for reading to & writing from GCS ---
 def read_from_gcs(gcs_uri: str) -> str:
     """Helper function to read text content from a GCS URI."""
@@ -56,27 +61,29 @@ def read_from_gcs(gcs_uri: str) -> str:
     # Parse the GCS URI (e.g., "gs://bucket-name/path/to/file.txt")
     parsed_uri = urlparse(gcs_uri)
     bucket_name = parsed_uri.netloc
-    blob_name = parsed_uri.path.lstrip('/')
-    
+    blob_name = parsed_uri.path.lstrip("/")
+
     # Get the specific bucket and blob
     # Note: Assumes file is in the *same project*
     # If not, you may need a more complex client initialization
     bucket = storage_client.bucket(bucket_name)
     blob = bucket.blob(blob_name)
-    
+
     if not blob.exists():
         raise FileNotFoundError(f"GCS file not found: {gcs_uri}")
-        
+
     return blob.download_as_text()
+
 
 def upload_to_gcs(content: str, destination_blob_name: str) -> str:
     """Helper function to upload text content to GCS and return its URI."""
     logger.info(f"Writing to GCS: gs://{GCS_BUCKET_NAME}/{destination_blob_name}")
     blob = gcs_bucket.blob(destination_blob_name)
-    blob.upload_from_string(content, content_type='text/plain; charset=utf-8')
-    
+    blob.upload_from_string(content, content_type="text/plain; charset=utf-8")
+
     # Return the GCS URI
     return f"gs://{GCS_BUCKET_NAME}/{destination_blob_name}"
+
 
 # --- Function 1: Generate Transcript ---
 @mcp.tool()
@@ -104,7 +111,9 @@ def generate_transcript(audio_file_uri: str, episode_name: str) -> str:
     elif audio_file_uri.lower().endswith(".wav"):
         file_mime_type = "audio/wav"
     else:
-        raise ValueError("Unsupported audio file type. Only .mp3 and .wav are supported.")
+        raise ValueError(
+            "Unsupported audio file type. Only .mp3 and .wav are supported."
+        )
 
     # The text prompt to send to the model
     prompt = """
@@ -112,7 +121,7 @@ def generate_transcript(audio_file_uri: str, episode_name: str) -> str:
     Transcribe the following audio interview into a plain text format.
     Each line should represent a single utterance and follow this structure:
     [HH:MM:SS] Speaker Name: Spoken text
-    
+
     -   The timecode should be in square brackets, in the format [HH:MM:SS].
     -   Use "Speaker A," "Speaker B," etc., to identify different speakers.
     -   Each speaker's utterance should be on a new line.
@@ -129,14 +138,19 @@ def generate_transcript(audio_file_uri: str, episode_name: str) -> str:
     Now, transcribe the interview from the audio file.
     """
 
-    audio_file_part = types.Part.from_uri(file_uri=audio_file_uri, mime_type=file_mime_type)
+    audio_file_part = types.Part.from_uri(
+        file_uri=audio_file_uri, mime_type=file_mime_type
+    )
 
-    response = client.models.generate_content(model=MODEL_NAME, contents=[prompt, audio_file_part])
+    response = client.models.generate_content(
+        model=MODEL_NAME, contents=[prompt, audio_file_part]
+    )
 
     transcript_filename = f"{episode_name}_transcript.txt"
     gcs_uri = upload_to_gcs(response.text, transcript_filename)
     print(f"Transcription saved to {gcs_uri}")
     return gcs_uri
+
 
 # --- Function 2: Generate Show Notes ---
 @mcp.tool()
@@ -147,12 +161,12 @@ def generate_shownotes(transcript_gcs_uri: str, episode_name: str) -> str:
     Args:
         transcript_gcs_uri: The GCS URI of the transcript file.
         episode_name: The name of the episode, used to create the output filename.
-    
+
     Returns:
         The GCS URI of the generated shownotes file.
     """
     logger.info(f">>> 🛠️ Tool: 'generate_shownotes' called for '{transcript_gcs_uri}'")
-    
+
     try:
         transcript = read_from_gcs(transcript_gcs_uri)
     except FileNotFoundError as e:
@@ -180,6 +194,7 @@ Here is the transcript:
     print(f"Shownotes saved to {gcs_uri}")
     return gcs_uri
 
+
 # --- Function 3: Generate Blog Post ---
 @mcp.tool()
 def generate_blog_post(transcript_gcs_uri: str, episode_name: str) -> str:
@@ -194,7 +209,7 @@ def generate_blog_post(transcript_gcs_uri: str, episode_name: str) -> str:
         The GCS URI of the generated blog post file.
     """
     logger.info(f">>> 🛠️ Tool: 'generate_blog_post' called for '{transcript_gcs_uri}'")
-    
+
     try:
         transcript = read_from_gcs(transcript_gcs_uri)
     except FileNotFoundError as e:
@@ -232,8 +247,10 @@ def generate_social_media_posts(transcript_gcs_uri: str, episode_name: str) -> s
     Returns:
         The GCS URI of the generated social media posts file.
     """
-    logger.info(f">>> 🛠️ Tool: 'generate_social_media_posts' called for '{transcript_gcs_uri}'")
-    
+    logger.info(
+        f">>> 🛠️ Tool: 'generate_social_media_posts' called for '{transcript_gcs_uri}'"
+    )
+
     try:
         transcript = read_from_gcs(transcript_gcs_uri)
     except FileNotFoundError as e:


### PR DESCRIPTION
genai requires the project and region to be hardcoded, in lieu of an API key

Within the deployed Cloud Run environment, you can pull both these values dynamically. 

The project has a helper from google.auth, region doesn't (but I've provided a stdlib implementation)

The docs have been updated to remove these hardcodes. 

Also: 

 * black/isort applied
 * uses `--env-var-file` in deployment command