### PR TITLE
feat: demo to acquire id token and invoking Cloud Run service

### DIFF
--- a/app-dev/call-cloudrun-with-credentials/README.md
+++ b/app-dev/call-cloudrun-with-credentials/README.md
@@ -1,0 +1,154 @@
+# 🔐 Demo: Authenticated Cloud Run Requests from Any Source
+
+## Overview
+
+Cloud Run services are deployed with enabled authentication by default which reject unauthenticated traffic.
+While invoking the services from other Google Cloud resources is easy since they "inherit" the underlying credentials, external clients — such as local development machines, on-premises servers, or applications on other cloud — face additional challenges.
+
+This demo shows a reliable pattern for calling such Cloud Run services from absolutely anywhere, leveraging best practices and standard Google Cloud authentication mechanisms.
+
+For a more detailed explanation of the security principles involved, please read [Securely Call a Cloud Run Service from Anywhere](https://leoy.blog/posts/securely-call-cloud-run-service-from-anywhere/).
+
+## Quick Start
+
+To run the demo please follow the steps below.
+Before running the steps, please review the prerequisites to ensure that you can run the demo without interruptions.
+
+### 0. Prerequsites
+
+To run the demo you will need the following:
+
+* [gcloud CLI](https://docs.cloud.google.com/sdk/docs/install) installed on your machine.
+* Google Cloud project that is linked to a valid billing account.
+* Permissions to deploy a Cloud Run service and define IAM policies on the project.
+
+### 1. Deploy a Cloud Run service
+
+> [!IMPORTANT]
+> The commands below use the `PROJECT_ID` environment variable as a source of the project ID.
+> Set up the environment variable before you run the commands.
+
+Deploy a simple Cloud Run service called "hello".
+
+```bash
+gcloud run deploy hello-service \
+  --image "us-docker.pkg.dev/cloudrun/container/hello" \
+  --region us-central1 \
+  --no-allow-unauthenticated \
+  --project "${PROJECT_ID}"
+```
+
+The `--no-allow-unauthenticated` flag is used to  explicitly enforce authentication.
+The service is deployed into the `us-central1` region. You can change the region to be closer to your geographic location.
+
+Once the deployment command exits, retrieve the URL of the service.
+
+```bash
+SERVICE_URL=$(gcloud run services describe hello-service \
+  --region us-central1 \
+  --project "${PROJECT_ID}" \
+  --format 'value(status.url)')
+```
+
+If you changed the location where the service is deployed in the previous command, update the region parameter in this command accordingly.
+
+### 2. Grant access to the service to selected credentials
+
+Once the Cloud Run service allows only authenticated calls, the caller has to be authorized to call the service.
+Grant the `roles/run.invoker` role to the selected identity.
+This step shows two options. **Option A** to use a user account is better suited for developer environments and quick demos. **Option B** to use a service account is more aligned with production-ready environments.
+
+* **Option A: Authorize user account to call the Cloud Run service**
+  
+  Set up the user's email:
+
+  ```bash
+  USER_EMAIL="user@org.email"
+  ```
+
+  Grant the role `roles/run.invoker` on the service to the user:
+
+  ```bash
+  gcloud run services add-iam-policy-binding hello-service \
+    --region us-central1 \
+    --project "${PROJECT_ID}" \
+    --member="user:${USER_EMAIL}" \
+    --role='roles/run.invoker'
+  ```
+
+  Make sure that you keep the location of the service the same as in the previous commands.
+
+* **Option B: Authorize service account to call the Cloud Run service**
+  
+  Set up the user's email:
+
+  ```bash
+  SA_EMAIL="service_account@PROJECT_ID.iam.gserviceaccount.com"
+  ```
+
+  Grant the role `roles/run.invoker` on the service to the service account:
+
+  ```bash
+  gcloud run services add-iam-policy-binding hello-service \
+    --region us-central1 \
+    --project "${PROJECT_ID}" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role='roles/run.invoker'
+  ```
+
+  Make sure that you keep the location of the service the same as in the previous commands.
+
+Th to the identity you intend to use. Choose one of the following options based on your preferred authentication method.
+
+### 3. Set up application default credentials (ADC) in your environment
+
+The demo leverages [application default credentials](https://docs.cloud.google.com/docs/authentication/application-default-credentials).
+
+> [!WARNING]
+> Avoid statically store credentials in your product environment.
+
+* **Option A: Authenticate with a user account's credentials**
+
+  ```bash
+  gcloud auth application-default login
+  ```
+
+  When you run the command it either opens a browser window or prints a long URL that you will need to manuallly open in a browse. Following instructions to complete authentication. At the end the gcloud command will store the acquired credentials locally.
+
+* **Option B: Authenticate with service account's key**
+
+  > [!IMPORTANT]
+  > Please familiarize yourself with [best practices](https://docs.cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys) for managing service account keys before you continue.
+
+  [Generate](https://docs.cloud.google.com/iam/docs/keys-create-delete#creating) service account key and store it in your environment.
+  Set up reserved environment variable to the path to the key file.
+
+  ```bash
+  export GOOGLE_APPLICATION_CREDENTIALS='PATH/TO/SA/KEY/FILE'
+  ```
+
+### 4. Execute the demo
+
+#### Python
+
+> [!NOTE]
+> You may consider to create a [virtual environment](https://docs.python.org/3/library/venv.html) before running the following command.
+
+```bash
+cd python
+pip install -r requirements.txt
+python demo.py --url "${SERVICE_URL}"
+```
+
+Mind that the `SERVICE_URL` environment variable was set in the Step 1.
+The successful execution prints "`🎉 --- Response Content (First 200 chars) ---`" following first 200 symbols of the response.
+
+#### Other languages
+
+Demo clients in other languages will be provided later.
+
+## How It Works
+
+The demo uses Google SDK to detect current setup of [application default credentials](https://docs.cloud.google.com/docs/authentication/application-default-credentials) in your environment.
+It leverages credentials set up using gcloud CLI, service account credentials configured via reserved environment variable and metadata server which will work *\*ONLY\** in environments hosted on Google Cloud.
+The code acquires identity token and calls the provisioned Cloud Run service using [Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Authentication) HTTP header's Bearer method.

--- a/app-dev/call-cloudrun-with-credentials/python/demo.py
+++ b/app-dev/call-cloudrun-with-credentials/python/demo.py
@@ -1,0 +1,76 @@
+import google.auth
+from google.auth.credentials import Credentials, Scoped
+
+def get_creds(audience: str) -> Credentials:
+    print(f"👉 Acquiring application default credentials (ADC)...")
+    creds, _ = google.auth.default()
+    if isinstance(creds, Scoped):
+        print(f"👉 Setting up '{audience}' scope...")
+        scopes = [audience] if creds.scopes is None else [audience] + list(creds.scopes)
+        creds = creds.with_scopes(scopes)
+    return creds
+
+def get_id_token(audience: str) -> str:
+
+    creds = get_creds(audience)
+
+    if hasattr(creds, "id_token") and creds.id_token:
+        print(f"🎉 Id token is acquired from ADC.")
+        return creds.id_token
+    else:
+        from google.oauth2 import id_token
+        from google.auth.transport.requests import Request
+        from google.auth.exceptions import RefreshError
+        
+        auth_req = Request()
+        try:
+            print(f"👉 Refreshing credentials to acquire ID token...")
+            creds.refresh(auth_req)
+        except RefreshError as e:
+            if not "No access token in response" in str(e):
+                raise
+        if hasattr(creds, "id_token") and creds.id_token:
+            print(f"🎉 Id token is acquired after refresh.")
+            return creds.id_token
+        elif audience:
+            print(f"👉 Fetching ID token from metadata server...")
+            return id_token.fetch_id_token(auth_req, audience)
+        else:
+            raise ValueError("Cannot obtain ID token without a specified audience.")
+
+def main():
+    import argparse
+    import requests
+
+    # Set up argument parser and read URL argument
+    parser = argparse.ArgumentParser(description="Demo script for argument parsing.")
+    parser.add_argument('--url', type=str, required=True, help='Cloud Run service URL')
+    args = parser.parse_args()
+
+    # Acquire credentials
+    token = get_id_token(args.url)
+
+    print(f"🎉 ID token is ready for use in authenticated call to Cloud Run.")
+    # Send authenticated request to the Cloud Run service
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    try:
+        print(f"👉 Calling Cloud Run service endpoint {args.url} with ID token...")
+        response = requests.get(args.url, headers=headers)
+        response.raise_for_status() # Raises an HTTPError for bad responses (4xx or 5xx)
+    
+        print(f"🎉 --- Response Content (First 200 chars) ---\n")
+        print(response.text[:200] + "...")
+    except requests.exceptions.HTTPError as e:
+        print(f"❌ HTTP Error: {e}")
+        print(f"❌ --- Response Content (First 200 chars) ---\n")
+        print(response.text[:200] + "...")
+    except requests.exceptions.RequestException as e:
+        print(f"❌ HTTP Error: {e}")
+        print(f"❌ --- Response Content (First 200 chars) ---\n")
+        print(response.text[:200] + "...")
+    
+if __name__ == "__main__":
+    main()

--- a/app-dev/call-cloudrun-with-credentials/python/requirements.txt
+++ b/app-dev/call-cloudrun-with-credentials/python/requirements.txt
@@ -1,0 +1,3 @@
+argparse==1.4.0
+requests>=2.32
+google.auth>=2.43


### PR DESCRIPTION
Implements a short demo in Python that shows a way to acquire ID token for calls to Cloud Run services with enabled authentication.
The demo includes a step-by-step README guide and an example in Python.

Additional PRs will be submitted later to provide demos in the rest of the golden languages.