### PR TITLE
fix: pin liteLLM upper bound to 1.82.6 to mitigate supply chain attack

### DIFF
--- a/agents/aicamp/pyproject.toml
+++ b/agents/aicamp/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = "==3.12.*"
 dependencies = [
     "google-adk>=1.22.1",
     "huggingface-hub>=1.3.2",
-    "litellm>=1.81.1",
+    "litellm>=1.81.1, <=1.82.6",
     "sqlite-rag>=0.1.4",
 ]
 

--- a/agents/aida/pyproject.toml
+++ b/agents/aida/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = "==3.12.*"
 dependencies = [
     "google-adk>=1.19.0",
-    "litellm>=1.80.7",
+    "litellm>=1.80.7, <=1.82.6",
     "sqlite-rag>=0.1.4",
     "fastapi",
     "uvicorn",


### PR DESCRIPTION
## Summary

liteLLM versions **1.82.7** and **1.82.8** were compromised by the **TeamPCP** group via a supply chain attack through Trivy. The current dependency constraint allows these malicious versions to be installed.

## Impact

The compromised versions steal sensitive credentials including SSH keys, AWS/GCP/K8s credentials, CI/CD tokens, and environment variables. Version 1.82.8 installs a `.pth` persistence mechanism that executes on every Python startup — even after liteLLM is uninstalled.

## Fix

This PR pins the upper bound of the liteLLM dependency to `<=1.82.6`, which is the last known safe version before the compromise. Once BerriAI publishes a verified clean release, this upper bound can be raised.

## References

- [BerriAI/litellm#24512](https://github.com/BerriAI/litellm/issues/24512) — Incident report
- [Wiz.io Analysis](https://www.wiz.io/blog/threes-a-crowd-teampcp-trojanizes-litellm-in-continuation-of-campaign) — Attack chain analysis
- [OSV: MAL-2026-2144](https://osv.dev/vulnerability/MAL-2026-2144) — Advisory