### PR TITLE
fix: ensure that each call to the gemma model has up to date token

### DIFF
--- a/agents/multi-agent-system/agents/content_builder/agent.py
+++ b/agents/multi-agent-system/agents/content_builder/agent.py
@@ -1,15 +1,16 @@
 import os
 import litellm
-import google.auth.transport.requests
-from google.oauth2 import id_token
 from google.adk.agents import Agent
 from google.adk.models import LiteLlm
 from litellmclientx import AuthLiteLLMClient
 
 # Fetch the ID token that's needed for Cloud Run
-target_url = os.environ.get("OLLAMA_API_BASE", "http://localhost:11434")
-auth_req = google.auth.transport.requests.Request()
-token = id_token.fetch_id_token(auth_req, target_url)
+target_url = os.environ.get("OLLAMA_API_BASE", "")
+if not target_url:
+    print(
+        "Failed to read URL from OLLAMA_API_BASE. Set OLLAMA_API_BASE to the valid Gemma model endpoint."
+    )
+    exit(1)
 
 # Instantiate the model
 # (Note: We use 'ollama/gemma3:270m' to align with ADK's expected prefix)

--- a/agents/multi-agent-system/agents/content_builder/agent.py
+++ b/agents/multi-agent-system/agents/content_builder/agent.py
@@ -4,22 +4,22 @@ import google.auth.transport.requests
 from google.oauth2 import id_token
 from google.adk.agents import Agent
 from google.adk.models import LiteLlm
+from litellmclientx import AuthLiteLLMClient
 
 # Fetch the ID token that's needed for Cloud Run
 target_url = os.environ.get("OLLAMA_API_BASE", "http://localhost:11434")
 auth_req = google.auth.transport.requests.Request()
 token = id_token.fetch_id_token(auth_req, target_url)
 
-# Instantiate the model 
+# Instantiate the model
 # (Note: We use 'ollama/gemma3:270m' to align with ADK's expected prefix)
 gemma_model_name = os.environ.get("GEMMA_MODEL_NAME", "gemma3:270m")
 model = LiteLlm(
-    model=f"ollama_chat/{gemma_model_name}", 
     api_base=target_url,
-    extra_headers={
-        "Authorization": f"Bearer {token}",
-},
+    llm_client=AuthLiteLLMClient(),
+    model=f"ollama_chat/{gemma_model_name}",
 )
+
 
 # 5. Define the Agent
 content_builder = Agent(

--- a/agents/multi-agent-system/agents/content_builder/litellmclientx.py
+++ b/agents/multi-agent-system/agents/content_builder/litellmclientx.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any, Optional, Union
 from google.adk.models.lite_llm import LiteLLMClient
 import google.auth.transport.requests
@@ -11,20 +10,15 @@ def get_auth_token() -> Optional[str]:
     audience = os.getenv("OLLAMA_API_BASE", "")
     try:
         creds, _ = google.auth.default()
-        print("DEBUG: acquiring credentials")
         # if user credentials are used
         if hasattr(creds, "id_token") and creds.id_token:
-            print("DEBUG: ID token in credentials")
             return creds.id_token
-        print("DEBUG: trying to refresh")
         auth_req = google.auth.transport.requests.Request()
         creds.refresh(auth_req)
         if hasattr(creds, "id_token") and creds.id_token:
-            print("DEBUG: ID token acquired after refresh")
             return creds.id_token
         # if service account credentials are used
         fetched_id_token = id_token.fetch_id_token(auth_req, audience)
-        print(f"DEBUG: ID token fetched with audience '{audience}'")
         return fetched_id_token
     except Exception as e:
         print(f"Error obtaining ID token for {audience}: {e}")

--- a/agents/multi-agent-system/agents/content_builder/litellmclientx.py
+++ b/agents/multi-agent-system/agents/content_builder/litellmclientx.py
@@ -6,15 +6,13 @@ import google.auth.transport.requests
 from google.oauth2 import id_token
 from litellm import CustomStreamWrapper, ModelResponse
 
+creds, _ = google.auth.default()
+
 
 def get_auth_token() -> Optional[str]:
     """Obtains a Google ID token for the given audience (Cloud Run service URL)."""
     audience = os.getenv("OLLAMA_API_BASE", "")
     try:
-        creds, _ = google.auth.default()
-        # if user credentials are used
-        if hasattr(creds, "id_token") and creds.id_token:
-            return creds.id_token
         auth_req = google.auth.transport.requests.Request()
         creds.refresh(auth_req)
         if hasattr(creds, "id_token") and creds.id_token:

--- a/agents/multi-agent-system/agents/content_builder/litellmclientx.py
+++ b/agents/multi-agent-system/agents/content_builder/litellmclientx.py
@@ -1,5 +1,6 @@
 from typing import Any, Optional, Union
 from google.adk.models.lite_llm import LiteLLMClient
+import google.auth
 import google.auth.transport.requests
 from google.oauth2 import id_token
 from litellm import CustomStreamWrapper, ModelResponse

--- a/agents/multi-agent-system/agents/content_builder/litellmclientx.py
+++ b/agents/multi-agent-system/agents/content_builder/litellmclientx.py
@@ -27,7 +27,7 @@ def get_auth_token() -> Optional[str]:
 
 class AuthLiteLLMClient(LiteLLMClient):
     """
-    Overrides the LiteLLMClient to inject a custom httpx.AsyncClient.
+    Overrides the LiteLLMClient to inject a bearer token into the request headers.
     """
 
     def __init__(self, **data: Any) -> None:

--- a/agents/multi-agent-system/agents/content_builder/litellmclientx.py
+++ b/agents/multi-agent-system/agents/content_builder/litellmclientx.py
@@ -1,0 +1,55 @@
+import os
+from typing import Any, Optional, Union
+from google.adk.models.lite_llm import LiteLLMClient
+from litellm import CustomStreamWrapper, ModelResponse
+
+
+def get_auth_token() -> Optional[str]:
+    """Obtains a Google ID token for the given audience (Cloud Run service URL)."""
+    audience = os.getenv("OLLAMA_API_BASE", "")
+    try:
+        creds, _ = google.auth.default()
+        print("DEBUG: acquiring credentials")
+        # if user credentials are used
+        if hasattr(creds, "id_token") and creds.id_token:
+            print("DEBUG: ID token in credentials")
+            return creds.id_token
+        print("DEBUG: trying to refresh")
+        auth_req = google.auth.transport.requests.Request()
+        creds.refresh(auth_req)
+        if hasattr(creds, "id_token") and creds.id_token:
+            print("DEBUG: ID token acquired after refresh")
+            return creds.id_token
+        # if service account credentials are used
+        fetched_id_token = id_token.fetch_id_token(auth_req, audience)
+        print(f"DEBUG: ID token fetched with audience '{audience}'")
+        return fetched_id_token
+    except Exception as e:
+        print(f"Error obtaining ID token for {audience}: {e}")
+        return None
+
+
+class AuthLiteLLMClient(LiteLLMClient):
+    """
+    Overrides the LiteLLMClient to inject a custom httpx.AsyncClient.
+    """
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+
+    async def acompletion(
+        self, model, messages, tools, **kwargs
+    ) -> Union[ModelResponse, CustomStreamWrapper]:
+        """
+        Updating headers to inject bearer token.
+        """
+
+        token: str = get_auth_token()
+        if "extra_headers" not in kwargs or kwargs["extra_headers"] is None:
+            kwargs["extra_headers"] = {}
+        kwargs["extra_headers"]["Authorization"] = f"Bearer {token}"
+
+        # Ensure we call the parent class acompletion to preserve ADK internal logic
+        return await super().acompletion(
+            model=model, messages=messages, tools=tools, **kwargs
+        )

--- a/agents/multi-agent-system/agents/content_builder/litellmclientx.py
+++ b/agents/multi-agent-system/agents/content_builder/litellmclientx.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Optional, Union
 from google.adk.models.lite_llm import LiteLLMClient
 import google.auth

--- a/agents/multi-agent-system/agents/content_builder/litellmclientx.py
+++ b/agents/multi-agent-system/agents/content_builder/litellmclientx.py
@@ -1,6 +1,8 @@
 import os
 from typing import Any, Optional, Union
 from google.adk.models.lite_llm import LiteLLMClient
+import google.auth.transport.requests
+from google.oauth2 import id_token
 from litellm import CustomStreamWrapper, ModelResponse
 
 


### PR DESCRIPTION
Introduce a customized `LiteLLMClient` class that acquires auth token on each call and substitutes it to the call to litellm acompletion() call.