### PR TITLE
Set location global for gemini-3 in agents/build-with-ai/production-r…

### DIFF
--- a/agents/build-with-ai/production-ready-ai/prai-roadshow-lab-1-complete/run_local.sh
+++ b/agents/build-with-ai/production-ready-ai/prai-roadshow-lab-1-complete/run_local.sh
@@ -6,7 +6,7 @@ lsof -ti:8000,8001,8002,8003,8004 | xargs kill -9 2>/dev/null
 
 # Set common environment variables for local development
 export GOOGLE_CLOUD_PROJECT=$(gcloud config get-value project)
-export GOOGLE_CLOUD_LOCATION="us-central1"
+export GOOGLE_CLOUD_LOCATION="global"
 export GOOGLE_GENAI_USE_VERTEXAI="True" # Use Gemini API locally
 export GOOGLE_API_KEY="<your-key-here>" # Use if not using Vertex AI
 

--- a/agents/build-with-ai/production-ready-ai/prai-roadshow-lab-1-starter/run_local.sh
+++ b/agents/build-with-ai/production-ready-ai/prai-roadshow-lab-1-starter/run_local.sh
@@ -6,7 +6,7 @@ lsof -ti:8000,8001,8002,8003,8004 | xargs kill -9 2>/dev/null
 
 # Set common environment variables for local development
 export GOOGLE_CLOUD_PROJECT=$(gcloud config get-value project)
-export GOOGLE_CLOUD_LOCATION="us-central1"
+export GOOGLE_CLOUD_LOCATION="global"
 export GOOGLE_GENAI_USE_VERTEXAI="True" # Use Gemini API locally
 export GOOGLE_API_KEY="<your-key-here>" # Use if not using Vertex AI
 


### PR DESCRIPTION
Change `GOOGLE_CLOUD_LOCATION` var to `global` for "gemini-3-flash-preview" in `agents/build-with-ai/production-ready-ai/prai-roadshow-lab-1-starter` to fix error:
```
404 NOT_FOUND. {'error': {'code': 404, 'message': 'Publisher Model projects/PROJECT/locations/us-central1/publishers/google/models/gemini-3-flash-preview was not found or your project does not have access to it. Please ensure you are using a valid model version. For more information, see: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions', 'status': 'NOT_FOUND'}}404 NOT_FOUND. {'error': {'code': 404, 'message': 'Publisher Model projects/PROJECT/locations/us-central1/publishers/google/models/gemini-3-flash-preview was not found or your project does not have access to it. Please ensure you are using a valid model version. For more information, see: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions', 'status': 'NOT_FOUND'}}
```