### PR TITLE
fix(scripts): enable Resource Manager API, ensure idempotency, and silence RAB warnings

### DIFF
--- a/codelabs/agentic-data-labs/scripts/setup.sh
+++ b/codelabs/agentic-data-labs/scripts/setup.sh
@@ -96,6 +96,7 @@ APIS=(
   storage.googleapis.com
   dataplex.googleapis.com
   bigqueryconnection.googleapis.com
+  cloudresourcemanager.googleapis.com
 )
 
 for api in "${APIS[@]}"; do
@@ -112,7 +113,7 @@ log_step "2" "Creating GCS bucket"
 if gcloud storage ls "$GCS_BUCKET" &>/dev/null; then
   log_warn "Bucket ${GCS_BUCKET} already exists. Reusing it."
 else
-  gcloud storage buckets create "$GCS_BUCKET" --project="$PROJECT_ID" --location="$REGION" --quiet
+  gcloud storage buckets create "$GCS_BUCKET" --project="$PROJECT_ID" --location="$REGION" --quiet 2>/dev/null
   log_ok "Created bucket ${GCS_BUCKET}"
 fi
 
@@ -134,7 +135,7 @@ log_ok "Dataset ${TARGET_DATASET} ready."
 
 log_info "Loading customers from PARQUET..."
 bq query --project_id="$PROJECT_ID" --use_legacy_sql=false --quiet \
-  "LOAD DATA INTO \`${PROJECT_ID}.${TARGET_DATASET}.customers\`
+  "LOAD DATA OVERWRITE \`${PROJECT_ID}.${TARGET_DATASET}.customers\`
    OPTIONS(description='Cymbal Pets customers table')
    FROM FILES (
      uris = ['${SOURCE_BUCKET}/customers/*.parquet'],
@@ -144,7 +145,7 @@ log_ok "customers loaded."
 
 log_info "Loading orders from PARQUET..."
 bq query --project_id="$PROJECT_ID" --use_legacy_sql=false --quiet \
-  "LOAD DATA INTO \`${PROJECT_ID}.${TARGET_DATASET}.orders\`
+  "LOAD DATA OVERWRITE \`${PROJECT_ID}.${TARGET_DATASET}.orders\`
    OPTIONS(description='Cymbal Pets orders table')
    FROM FILES (
      uris = ['${SOURCE_BUCKET}/orders/*.parquet'],
@@ -154,7 +155,7 @@ log_ok "orders loaded."
 
 log_info "Loading order_items from PARQUET..."
 bq query --project_id="$PROJECT_ID" --use_legacy_sql=false --quiet \
-  "LOAD DATA INTO \`${PROJECT_ID}.${TARGET_DATASET}.order_items\`
+  "LOAD DATA OVERWRITE \`${PROJECT_ID}.${TARGET_DATASET}.order_items\`
    OPTIONS(description='Cymbal Pets order items table')
    FROM FILES (
      uris = ['${SOURCE_BUCKET}/order_items/*.parquet'],
@@ -164,7 +165,7 @@ log_ok "order_items loaded."
 
 log_info "Loading products from PARQUET..."
 bq query --project_id="$PROJECT_ID" --use_legacy_sql=false --quiet \
-  "LOAD DATA INTO \`${PROJECT_ID}.${TARGET_DATASET}.products\`
+  "LOAD DATA OVERWRITE \`${PROJECT_ID}.${TARGET_DATASET}.products\`
    OPTIONS(description='Cymbal Pets products table')
    FROM FILES (
      uris = ['${SOURCE_BUCKET}/products/*.parquet'],
@@ -174,7 +175,7 @@ log_ok "products loaded."
 
 log_info "Loading pet_profiles from PARQUET..."
 bq query --project_id="$PROJECT_ID" --use_legacy_sql=false --quiet \
-  "LOAD DATA INTO \`${PROJECT_ID}.${TARGET_DATASET}.pet_profiles\`
+  "LOAD DATA OVERWRITE \`${PROJECT_ID}.${TARGET_DATASET}.pet_profiles\`
    OPTIONS(description='Cymbal Pets pet profiles table')
    FROM FILES (
      uris = ['${SOURCE_BUCKET}/pet_profiles/*.parquet'],
@@ -410,7 +411,7 @@ done
 # =============================================================================
 log_step "6" "Uploading promotional event data to GCS"
 
-gcloud storage cp ../data/promo_events.json "${GCS_BUCKET}/promo_events.json"
+gcloud storage cp ../data/promo_events.json "${GCS_BUCKET}/promo_events.json" 2>/dev/null
 log_ok "Promotional data uploaded to ${GCS_BUCKET}/promo_events.json"
 
 # =============================================================================

--- a/codelabs/agentic-data-labs/scripts/setup_sql.sh
+++ b/codelabs/agentic-data-labs/scripts/setup_sql.sh
@@ -159,7 +159,7 @@ log_info "Waiting for GCS CSV exports to complete..."
 MAX_WAIT_ATTEMPTS=100
 WAIT_ATTEMPT=0
 while ! gcloud storage ls "${GCS_BUCKET}/export/products.csv" &>/dev/null; do
-  ((WAIT_ATTEMPT++))
+  ((++WAIT_ATTEMPT))
   if [ $WAIT_ATTEMPT -ge $MAX_WAIT_ATTEMPTS ]; then
     log_error "Timed out waiting for CSV exports in GCS after $((MAX_WAIT_ATTEMPTS * 3))s. Did setup.sh complete successfully?"
     exit 1

--- a/codelabs/agentic-data-labs/scripts/setup_sql.sh
+++ b/codelabs/agentic-data-labs/scripts/setup_sql.sh
@@ -156,7 +156,14 @@ fi
 
 # Wait for GCS CSV exports to be fully completed by the foreground script
 log_info "Waiting for GCS CSV exports to complete..."
+MAX_WAIT_ATTEMPTS=100
+WAIT_ATTEMPT=0
 while ! gcloud storage ls "${GCS_BUCKET}/export/products.csv" &>/dev/null; do
+  ((WAIT_ATTEMPT++))
+  if [ $WAIT_ATTEMPT -ge $MAX_WAIT_ATTEMPTS ]; then
+    log_error "Timed out waiting for CSV exports in GCS after $((MAX_WAIT_ATTEMPTS * 3))s. Did setup.sh complete successfully?"
+    exit 1
+  fi
   sleep 3
 done
 log_ok "GCS CSV files detected. Proceeding with database loading."
@@ -203,7 +210,7 @@ END \$\$;
 EOF
 fi
 
-gcloud storage cp /tmp/_init_db.sql "${GCS_BUCKET}/temp/_init_db.sql" --quiet > /dev/null
+gcloud storage cp /tmp/_init_db.sql "${GCS_BUCKET}/temp/_init_db.sql" --quiet > /dev/null 2>&1
 log_info "Executing schema DDL and user grant scripts..."
 if ! gcloud sql import sql "$CLOUDSQL_INSTANCE" \
   "${GCS_BUCKET}/temp/_init_db.sql" \


### PR DESCRIPTION
On silencing Regional Access Boundary (RAB) - these are noise from `gcloud storage` that occur when the authenticated account doesn't use RAB policies. Since every affected command has the explicit success/failure logging and the script runs under `set -euo pipefail`, real errors still halt execution.