### PR TITLE
feat: add hackathon deletion with DB persistence, visual layout corrections, and unit tests

### DIFF
--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/domain/hackathon.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/domain/hackathon.go
@@ -37,4 +37,5 @@ type Hackathon struct {
 type HackathonRepository interface {
 	GetAll() ([]Hackathon, error)
 	GetByID(id string) (Hackathon, error)
+	Create(hackathon Hackathon) error
 }

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/domain/hackathon.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/domain/hackathon.go
@@ -38,4 +38,5 @@ type HackathonRepository interface {
 	GetAll() ([]Hackathon, error)
 	GetByID(id string) (Hackathon, error)
 	Create(hackathon Hackathon) error
+	Delete(id string) error
 }

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/domain/project.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/domain/project.go
@@ -33,4 +33,5 @@ type ProjectRepository interface {
 	GetByHackathonID(hackathonID string) ([]Project, error)
 	GetProjectByID(id string) (Project, error)
 	UpdateScore(projectID string, score float64) error
+	CreateProject(project Project) error
 }

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/handler/hackathon_handler.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/handler/hackathon_handler.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/moficodes/hackathon-judge/backend/internal/domain"
 	"github.com/moficodes/hackathon-judge/backend/internal/service"
 )
 
@@ -39,6 +40,8 @@ func (h *HackathonHandler) RegisterRoutes(r *gin.Engine) {
 		api.GET("/projects/:id", h.GetProject)
 		api.GET("/projects/:id/evaluations", h.GetEvaluations)
 		api.POST("/projects/:id/judge", h.TriggerJudgingAgent)
+		api.POST("/hackathons", h.CreateHackathon)
+		api.POST("/hackathons/:id/projects", h.CreateProject)
 	}
 }
 
@@ -115,3 +118,47 @@ func (h *HackathonHandler) TriggerJudgingAgent(c *gin.Context) {
 		"task_id": taskID,
 	})
 }
+
+func (h *HackathonHandler) CreateHackathon(c *gin.Context) {
+	var req domain.Hackathon
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body: " + err.Error()})
+		return
+	}
+	
+	if req.Title == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Title is required"})
+		return
+	}
+
+	if err := h.svc.CreateHackathon(req); err != nil {
+		log.Printf("[ERROR] CreateHackathon failed: %v\n", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, req)
+}
+
+func (h *HackathonHandler) CreateProject(c *gin.Context) {
+	hackathonID := c.Param("id")
+	var req domain.Project
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body: " + err.Error()})
+		return
+	}
+
+	if req.Name == "" || req.Title == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Name and Title are required"})
+		return
+	}
+
+	req.HackathonID = hackathonID
+
+	if err := h.svc.CreateProject(req); err != nil {
+		log.Printf("[ERROR] CreateProject failed: %v\n", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, req)
+}
+

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/handler/hackathon_handler.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/handler/hackathon_handler.go
@@ -42,6 +42,7 @@ func (h *HackathonHandler) RegisterRoutes(r *gin.Engine) {
 		api.POST("/projects/:id/judge", h.TriggerJudgingAgent)
 		api.POST("/hackathons", h.CreateHackathon)
 		api.POST("/hackathons/:id/projects", h.CreateProject)
+		api.DELETE("/hackathons/:id", h.DeleteHackathon)
 	}
 }
 
@@ -160,5 +161,15 @@ func (h *HackathonHandler) CreateProject(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusCreated, req)
+}
+
+func (h *HackathonHandler) DeleteHackathon(c *gin.Context) {
+	id := c.Param("id")
+	if err := h.svc.DeleteHackathon(id); err != nil {
+		log.Printf("[ERROR] DeleteHackathon failed for %s: %v\n", id, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Hackathon deleted successfully"})
 }
 

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/handler/hackathon_handler_test.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/handler/hackathon_handler_test.go
@@ -169,3 +169,28 @@ func TestGetProject_NotFound(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
+
+func TestDeleteHackathon(t *testing.T) {
+	r, _ := setupRouter()
+
+	req, _ := http.NewRequest(http.MethodDelete, "/api/hackathons/1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var res map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &res)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hackathon deleted successfully", res["message"])
+}
+
+func TestDeleteHackathon_NotFound(t *testing.T) {
+	r, _ := setupRouter()
+
+	req, _ := http.NewRequest(http.MethodDelete, "/api/hackathons/invalid_id", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/repository/bigquery_repo.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/repository/bigquery_repo.go
@@ -576,3 +576,28 @@ func (r *BigQueryRepo) CreateProject(project domain.Project) error {
 	return nil
 }
 
+func (r *BigQueryRepo) Delete(id string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	query := r.client.Query(fmt.Sprintf(`
+		DELETE FROM `+"`"+`%s.%s.hackathons`+"`"+` WHERE id = @id`, r.projectID, r.datasetID))
+
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "id", Value: id},
+	}
+
+	job, err := query.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to run delete query for hackathon: %w", err)
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to wait for delete query for hackathon: %w", err)
+	}
+	if status.Err() != nil {
+		return fmt.Errorf("delete query failed for hackathon: %w", status.Err())
+	}
+	return nil
+}
+

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/repository/bigquery_repo.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/repository/bigquery_repo.go
@@ -483,3 +483,96 @@ func (r *BigQueryRepo) GetByProjectID(projectID string) ([]domain.Evaluation, er
 
 	return evaluations, nil
 }
+
+func (r *BigQueryRepo) Create(hackathon domain.Hackathon) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	bqCriteria := make([]bqCriterion, len(hackathon.Criteria))
+	for i, c := range hackathon.Criteria {
+		bqCriteria[i] = bqCriterion{
+			ID:          fmt.Sprintf("crit_%d", i),
+			Name:        c.Name,
+			Description: c.Description,
+			Weight:      c.Weight,
+			Score:       0,
+			MaxScore:    c.MaxScore,
+		}
+	}
+
+	bqBonusCriteria := make([]bqCriterion, len(hackathon.BonusCriteria))
+	for i, c := range hackathon.BonusCriteria {
+		bqBonusCriteria[i] = bqCriterion{
+			ID:          fmt.Sprintf("bonus_%d", i),
+			Name:        c.Name,
+			Description: c.Description,
+			Weight:      c.Weight,
+			Score:       0,
+			MaxScore:    c.MaxScore,
+		}
+	}
+
+	query := r.client.Query(fmt.Sprintf(`
+		INSERT INTO `+"`"+`%s.%s.hackathons`+"`"+` (id, title, date, description, goal, status, criteria, bonus_criteria) 
+		VALUES (@id, @title, @date, @description, @goal, @status, @criteria, @bonus_criteria)`, r.projectID, r.datasetID))
+
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "id", Value: hackathon.ID},
+		{Name: "title", Value: hackathon.Title},
+		{Name: "date", Value: hackathon.Date},
+		{Name: "description", Value: hackathon.Description},
+		{Name: "goal", Value: hackathon.Goal},
+		{Name: "status", Value: hackathon.Status},
+		{Name: "criteria", Value: bqCriteria},
+		{Name: "bonus_criteria", Value: bqBonusCriteria},
+	}
+
+	job, err := query.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to run insert query for hackathon: %w", err)
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to wait for insert query for hackathon: %w", err)
+	}
+	if status.Err() != nil {
+		return fmt.Errorf("insert query failed for hackathon: %w", status.Err())
+	}
+	return nil
+}
+
+func (r *BigQueryRepo) CreateProject(project domain.Project) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	query := r.client.Query(fmt.Sprintf(`
+		INSERT INTO `+"`"+`%s.%s.projects`+"`"+` (id, name, title, url, readme_ref, github_url, team_name, document, processing_date, hackathon_id, score) 
+		VALUES (@id, @name, @title, @url, NULL, @github_url, @team_name, @document, @processing_date, @hackathon_id, @score)`, r.projectID, r.datasetID))
+
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "id", Value: project.ID},
+		{Name: "name", Value: project.Name},
+		{Name: "title", Value: project.Title},
+		{Name: "url", Value: project.URL},
+		{Name: "github_url", Value: project.GitHubURL},
+		{Name: "team_name", Value: project.TeamName},
+		{Name: "document", Value: project.Document},
+		{Name: "processing_date", Value: project.Date},
+		{Name: "hackathon_id", Value: project.HackathonID},
+		{Name: "score", Value: project.Score},
+	}
+
+	job, err := query.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to run insert query for project: %w", err)
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to wait for insert query for project: %w", err)
+	}
+	if status.Err() != nil {
+		return fmt.Errorf("insert query failed for project: %w", status.Err())
+	}
+	return nil
+}
+

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/repository/memory_repo.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/repository/memory_repo.go
@@ -149,3 +149,18 @@ func (r *memoryRepo) GetProjectByID(id string) (domain.Project, error) {
 	}
 	return domain.Project{}, errors.New("project not found")
 }
+
+func (r *memoryRepo) Create(hackathon domain.Hackathon) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hackathons = append(r.hackathons, hackathon)
+	return nil
+}
+
+func (r *memoryRepo) CreateProject(project domain.Project) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.projects = append(r.projects, project)
+	return nil
+}
+

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/repository/memory_repo.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/repository/memory_repo.go
@@ -164,3 +164,15 @@ func (r *memoryRepo) CreateProject(project domain.Project) error {
 	return nil
 }
 
+func (r *memoryRepo) Delete(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, h := range r.hackathons {
+		if h.ID == id {
+			r.hackathons = append(r.hackathons[:i], r.hackathons[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("hackathon not found")
+}
+

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/service/hackathon_service.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/service/hackathon_service.go
@@ -34,6 +34,7 @@ type HackathonService interface {
 	TriggerJudgingAgent(projectID string) (string, error)
 	CreateHackathon(hackathon domain.Hackathon) error
 	CreateProject(project domain.Project) error
+	DeleteHackathon(id string) error
 }
 
 type hackathonService struct {
@@ -317,4 +318,8 @@ func (s *hackathonService) CreateProject(project domain.Project) error {
 	}
 	project.Score = 0
 	return s.projectRepo.CreateProject(project)
+}
+
+func (s *hackathonService) DeleteHackathon(id string) error {
+	return s.repo.Delete(id)
 }

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/service/hackathon_service.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/service/hackathon_service.go
@@ -32,6 +32,8 @@ type HackathonService interface {
 	SaveJudgingResult(res domain.JudgingResult) error
 	ListEvaluationsByProject(projectID string) ([]domain.Evaluation, error)
 	TriggerJudgingAgent(projectID string) (string, error)
+	CreateHackathon(hackathon domain.Hackathon) error
+	CreateProject(project domain.Project) error
 }
 
 type hackathonService struct {
@@ -291,4 +293,28 @@ func (s *hackathonService) SaveJudgingResult(res domain.JudgingResult) error {
 	}
 
 	return nil
+}
+
+func (s *hackathonService) CreateHackathon(hackathon domain.Hackathon) error {
+	if hackathon.ID == "" {
+		hackathon.ID = uuid.New().String()
+	}
+	if hackathon.Date.IsZero() {
+		hackathon.Date = time.Now()
+	}
+	if hackathon.Status == "" {
+		hackathon.Status = "active"
+	}
+	return s.repo.Create(hackathon)
+}
+
+func (s *hackathonService) CreateProject(project domain.Project) error {
+	if project.ID == "" {
+		project.ID = uuid.New().String()
+	}
+	if project.Date.IsZero() {
+		project.Date = time.Now()
+	}
+	project.Score = 0
+	return s.projectRepo.CreateProject(project)
 }

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/service/hackathon_service_test.go
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/backend/internal/service/hackathon_service_test.go
@@ -140,3 +140,25 @@ func TestCheckStuckEvaluations(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "SUCCESS", e.Status)
 }
+
+func TestDeleteHackathon(t *testing.T) {
+	repo := repository.NewMemoryRepo()
+	svc := service.NewHackathonService(repo, repo, repo, nil)
+
+	// Try deleting an existing hackathon
+	err := svc.DeleteHackathon("1")
+	assert.NoError(t, err)
+
+	// Subsequently getting the deleted hackathon should fail
+	_, err = svc.GetHackathon("1")
+	assert.Error(t, err)
+}
+
+func TestDeleteHackathon_NotFound(t *testing.T) {
+	repo := repository.NewMemoryRepo()
+	svc := service.NewHackathonService(repo, repo, repo, nil)
+
+	// Deleting a nonexistent hackathon should return an error
+	err := svc.DeleteHackathon("invalid_id")
+	assert.Error(t, err)
+}

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/cloudbuild.yaml
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/cloudbuild.yaml
@@ -70,10 +70,10 @@ images:
   - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/frontend:$COMMIT_SHA'
   - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/agent:$COMMIT_SHA'
   - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/agent-sandbox:$COMMIT_SHA'
-  - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/backend:latest'
-  - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/frontend:latest'
-  - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/agent:latest'
-  - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/agent-sandbox:latest'
+  - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/backend:$COMMIT_SHA'
+  - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/frontend:$COMMIT_SHA'
+  - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/agent:$COMMIT_SHA'
+  - '$_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/agent-sandbox:$COMMIT_SHA'
 
 substitutions:
   _REGION: us

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/deploy.sh
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/deploy.sh
@@ -537,7 +537,9 @@ if [ "$RUN_GKE" = "true" ]; then
 
       if gcloud container clusters create-auto "$CLUSTER_NAME" \
           --region="$GOOGLE_CLOUD_REGION" \
-          --project="$GOOGLE_CLOUD_PROJECT"; then
+          --project="$GOOGLE_CLOUD_PROJECT" \
+          --network="default" \
+          --subnetwork="default"; then
         log_success "GKE Autopilot cluster '$CLUSTER_NAME' successfully created!"
       else
         log_error "Failed to create GKE cluster. Please check your quota settings or regional resources."

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/nginx.conf
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/nginx.conf
@@ -2,10 +2,22 @@ server {
     listen 80;
     server_name localhost;
 
+    location = /index.html {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
+    }
+
+    location /assets/ {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
     location / {
         root /usr/share/nginx/html;
         index index.html index.htm;
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
     }
 
     location /api/ {

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/package-lock.json
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/package-lock.json
@@ -576,6 +576,474 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/App.test.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/App.test.tsx
@@ -15,15 +15,28 @@
  */
 
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import App from './App';
-import useSWR from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 
-vi.mock('swr');
+vi.mock('swr', () => {
+  const mockMutate = vi.fn();
+  return {
+    default: vi.fn(),
+    useSWRConfig: vi.fn(() => ({ mutate: mockMutate })),
+  };
+});
+
 const mockUseSWR = useSWR as unknown as ReturnType<typeof vi.fn>;
+const mockUseSWRConfig = useSWRConfig as unknown as ReturnType<typeof vi.fn>;
 
 describe('App Component', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockUseSWRConfig.mockReturnValue({ mutate: vi.fn() });
+  });
+
   it('renders the layout and home page', () => {
     mockUseSWR.mockReturnValue({ data: undefined, error: undefined, isLoading: true });
     render(
@@ -46,12 +59,13 @@ describe('App Component', () => {
 
   it('renders the dashboard page', () => {
     mockUseSWR.mockReturnValue({ data: undefined, error: undefined, isLoading: true });
-    render(
+    const { container } = render(
       <MemoryRouter initialEntries={['/dashboard']}>
         <App />
       </MemoryRouter>
     );
-    expect(screen.getByText(/Loading hackathons\.\.\./i)).toBeInTheDocument();
+    const skeleton = container.querySelector('.animate-pulse');
+    expect(skeleton).toBeInTheDocument();
   });
 
   it('renders the hackathon detail page', async () => {

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/components/Header.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/components/Header.tsx
@@ -52,9 +52,9 @@ export default function Header({ user = defaultUser, status = defaultStatus }: H
   }, []);
 
   return (
-    <header className="h-[64px] border-b border-slate-200 bg-white flex items-center justify-between px-lg z-20">
+    <header className="h-[64px] border-b border-slate-200 bg-white flex items-center justify-between px-md sm:px-lg z-20">
       {/* Left: Search */}
-      <div className="flex items-center gap-sm bg-slate-50 border border-slate-300 px-md py-xs rounded-md w-[320px] group focus-within:ring-2 focus-within:ring-secondary/20 focus-within:border-secondary transition-all">
+      <div className="hidden sm:flex items-center gap-sm bg-slate-50 border border-slate-300 px-md py-xs rounded-md sm:w-[200px] md:w-[320px] group focus-within:ring-2 focus-within:ring-secondary/20 focus-within:border-secondary transition-all">
         <Search className="w-4 h-4 text-slate-400" />
         <input 
           type="text" 
@@ -62,15 +62,15 @@ export default function Header({ user = defaultUser, status = defaultStatus }: H
           aria-label="Search"
           className="bg-transparent border-none outline-none text-sm w-full text-slate-900 placeholder:text-slate-500"
         />
-        <kbd className="hidden sm:inline-flex items-center gap-1 px-1.5 font-sans text-[10px] font-medium text-slate-400 bg-white border border-slate-300 rounded shadow-xs">
+        <kbd className="hidden md:inline-flex items-center gap-1 px-1.5 font-sans text-[10px] font-medium text-slate-400 bg-white border border-slate-300 rounded shadow-xs">
           ⌘K
         </kbd>
       </div>
 
       {/* Right: Utilities & User */}
-      <div className="flex items-center gap-xl">
+      <div className="flex items-center gap-md sm:gap-xl ml-auto">
         {/* Status Badge */}
-        <div className="flex items-center gap-xs bg-secondary-container/10 px-sm py-[2px] rounded-full border border-secondary-container/20">
+        <div className="hidden sm:flex items-center gap-xs bg-secondary-container/10 px-sm py-[2px] rounded-full border border-secondary-container/20">
           <div className="w-2 h-2 rounded-full bg-secondary"></div>
           <span className="text-[10px] font-bold text-secondary tracking-widest uppercase">
             {status}
@@ -78,7 +78,7 @@ export default function Header({ user = defaultUser, status = defaultStatus }: H
         </div>
 
         {/* Icons */}
-        <div className="flex items-center gap-md text-slate-600 relative">
+        <div className="flex items-center gap-sm sm:gap-md text-slate-600 relative">
           <div className="relative" ref={notificationRef}>
             <button 
               aria-label="Notifications" 
@@ -113,7 +113,7 @@ export default function Header({ user = defaultUser, status = defaultStatus }: H
         </div>
 
         {/* User Profile */}
-        <div className="flex items-center gap-md border-l border-slate-200 pl-xl cursor-pointer group">
+        <div className="flex items-center gap-sm sm:gap-md border-l border-slate-200 pl-md sm:pl-xl cursor-pointer group">
           <div className="w-8 h-8 rounded-full bg-slate-900 text-white flex items-center justify-center text-xs font-bold ring-2 ring-transparent group-hover:ring-secondary/20 transition-all">
             {user.initials}
           </div>

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/components/Layout.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/components/Layout.tsx
@@ -25,7 +25,7 @@ export default function Layout() {
       <div className="flex flex-col min-w-0">
         <Header />
         <main className="flex-1 bg-slate-50 overflow-y-auto">
-          <div className="max-w-7xl mx-auto p-xl">
+          <div className="max-w-7xl mx-auto p-md md:p-xl">
             <Outlet />
           </div>
         </main>

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/index.css
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/index.css
@@ -17,6 +17,9 @@
 @import "tailwindcss";
 
 /* Cache-busting hash reset to force browser style refresh: 20260710-0906 */
+.cache-buster-906 {
+  content: "20260710-0906";
+}
 
 @theme {
   /* Colors */

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/index.css
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/index.css
@@ -16,6 +16,8 @@
 
 @import "tailwindcss";
 
+/* Cache-busting hash reset to force browser style refresh: 20260710-0906 */
+
 @theme {
   /* Colors */
   --color-surface: #f8f9ff;

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/main.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/main.tsx
@@ -27,3 +27,6 @@ createRoot(document.getElementById('root')!).render(
     </BrowserRouter>
   </StrictMode>,
 )
+
+// Cache-busting bundle reset to force browser script refresh: 20260710-0906
+

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/main.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/main.tsx
@@ -26,7 +26,7 @@ createRoot(document.getElementById('root')!).render(
       <App />
     </BrowserRouter>
   </StrictMode>,
-)
+);
 
 // Active cache-buster assignment to force browser script refresh
 (window as any)._cacheBuster = "20260710-0906";

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/main.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/main.tsx
@@ -28,5 +28,7 @@ createRoot(document.getElementById('root')!).render(
   </StrictMode>,
 )
 
-// Cache-busting bundle reset to force browser script refresh: 20260710-0906
+// Active cache-buster assignment to force browser script refresh
+(window as any)._cacheBuster = "20260710-0906";
+
 

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/Dashboard.test.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/Dashboard.test.tsx
@@ -15,27 +15,53 @@
  */
 
 // src/pages/Dashboard.test.tsx
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Dashboard from './Dashboard';
-import useSWR from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 
-vi.mock('swr');
+vi.mock('swr', () => {
+  const mockMutate = vi.fn();
+  return {
+    default: vi.fn(),
+    useSWRConfig: vi.fn(() => ({ mutate: mockMutate })),
+  };
+});
 
 const mockUseSWR = useSWR as unknown as ReturnType<typeof vi.fn>;
+const mockUseSWRConfig = useSWRConfig as unknown as ReturnType<typeof vi.fn>;
 
 describe('Dashboard Component', () => {
-  it('renders loading state initially', () => {
+  let mockMutate: any;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockMutate = vi.fn();
+    mockUseSWRConfig.mockReturnValue({ mutate: mockMutate });
+    global.fetch = vi.fn() as any;
+  });
+
+  it('renders loading state (animated skeletons)', () => {
     mockUseSWR.mockReturnValue({ data: undefined, error: undefined, isLoading: true });
-    render(<BrowserRouter><Dashboard /></BrowserRouter>);
-    expect(screen.getByText('Loading hackathons...')).toBeInTheDocument();
+    const { container } = render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+    // Loading state renders skeleton grids containing divs with 'animate-pulse'
+    const skeletonGrid = container.querySelector('.animate-pulse');
+    expect(skeletonGrid).toBeInTheDocument();
   });
 
   it('renders error state', () => {
     mockUseSWR.mockReturnValue({ data: undefined, error: new Error('Failed to load'), isLoading: false });
-    render(<BrowserRouter><Dashboard /></BrowserRouter>);
-    expect(screen.getByText('Failed to load hackathons.')).toBeInTheDocument();
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+    expect(screen.getByText('Failed to sync hackathon dashboard.')).toBeInTheDocument();
   });
 
   it('renders hackathons data', async () => {
@@ -43,12 +69,61 @@ describe('Dashboard Component', () => {
       { id: '1', title: 'Spring Hackathon', date: '2026-05-15T00:00:00Z', status: 'upcoming', goal: 'Build cool stuff' },
     ];
     mockUseSWR.mockReturnValue({ data: mockData, error: undefined, isLoading: false });
-    
-    render(<BrowserRouter><Dashboard /></BrowserRouter>);
-    
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
     await waitFor(() => {
       expect(screen.getByText('Spring Hackathon')).toBeInTheDocument();
-      expect(screen.getByText('Status: upcoming')).toBeInTheDocument();
+      expect(screen.getByText('upcoming')).toBeInTheDocument();
+    });
+  });
+
+  it('handles the Delete Hackathon flow and confirms deletion', async () => {
+    const mockData = [
+      { id: '1', title: 'Spring Hackathon', date: '2026-05-15T00:00:00Z', status: 'upcoming', goal: 'Build cool stuff' },
+    ];
+    mockUseSWR.mockReturnValue({ data: mockData, error: undefined, isLoading: false });
+
+    // Mock successful fetch for deletion
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'Hackathon deleted successfully' }),
+    });
+
+    render(
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
+    );
+
+    // Verify card is loaded
+    await waitFor(() => {
+      expect(screen.getByText('Spring Hackathon')).toBeInTheDocument();
+    });
+
+    // Click the "Delete" button inside the tile
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    fireEvent.click(deleteButton);
+
+    // Verify deletion confirmation modal appears
+    expect(screen.getByText('Delete Hackathon')).toBeInTheDocument();
+    expect(screen.getByText(/Are you sure you want to delete this hackathon?/i)).toBeInTheDocument();
+
+    // Click the confirmation "Delete Permanently" button
+    const confirmDeleteButton = screen.getByRole('button', { name: /delete permanently/i });
+    fireEvent.click(confirmDeleteButton);
+
+    // Verify fetch was called with the correct URL & Method
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/hackathons/1', {
+        method: 'DELETE',
+      });
+      // Verify SWR mutation was triggered to refresh dashboard view
+      expect(mockMutate).toHaveBeenCalledWith('/api/hackathons');
     });
   });
 });

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/Dashboard.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/Dashboard.tsx
@@ -14,38 +14,603 @@
  * limitations under the License.
  */
 
-// src/pages/Dashboard.tsx
-import useSWR from 'swr';
+import React, { useState } from 'react';
+import useSWR, { useSWRConfig } from 'swr';
 import { Link } from 'react-router-dom';
 import { fetcher } from '../utils/fetcher';
 import type { Hackathon } from '../types/models';
+import { Plus, Trash, Calendar, Settings2, Award, ClipboardCheck, Sparkles, X, Check } from 'lucide-react';
+
+interface CriterionInput {
+  name: string;
+  description: string;
+  weight: number;
+  max_score: number;
+}
+
+const DEFAULT_CRITERIA: CriterionInput[] = [
+  { name: 'Innovation & Originality', description: 'How unique and creative is the solution?', weight: 0.3, max_score: 5 },
+  { name: 'Technical Execution', description: 'Code quality and technical execution completeness.', weight: 0.4, max_score: 5 },
+  { name: 'User Experience (UX/UI)', description: 'Minimalist design for flow-state productivity.', weight: 0.3, max_score: 5 }
+];
 
 export default function Dashboard() {
   const { data: hackathons, error, isLoading } = useSWR<Hackathon[]>('/api/hackathons', fetcher);
+  const { mutate } = useSWRConfig();
 
-  if (isLoading) return <div className="p-4">Loading hackathons...</div>;
-  if (error) return <div className="p-4 text-red-500">Failed to load hackathons.</div>;
-  if (!hackathons || hackathons.length === 0) return <div className="p-4">No hackathons found.</div>;
+  // Modal Toggles
+  const [isHackathonModalOpen, setIsHackathonModalOpen] = useState(false);
+  const [isProjectModalOpen, setIsProjectModalOpen] = useState(false);
+  const [selectedHackathonId, setSelectedHackathonId] = useState<string | null>(null);
+
+  // New Hackathon Form Fields
+  const [hackathonTitle, setHackathonTitle] = useState('');
+  const [hackathonDate, setHackathonDate] = useState('');
+  const [hackathonDesc, setHackathonDescription] = useState('');
+  const [hackathonGoal, setHackathonGoal] = useState('');
+  const [criteria, setCriteria] = useState<CriterionInput[]>(DEFAULT_CRITERIA);
+  const [bonusCriteria, setBonusCriteria] = useState<CriterionInput[]>([]);
+
+  // New Project Form Fields
+  const [projTitle, setProjTitle] = useState('');
+  const [projGit, setProjGit] = useState('');
+  const [projTeam, setProjTeam] = useState('');
+  const [projDoc, setProjDoc] = useState('');
+
+  // SWR Mutation Handling
+  const handleCreateHackathon = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    // Weight sum validation
+    const totalWeight = criteria.reduce((sum, c) => sum + Number(c.weight), 0);
+    if (Math.abs(totalWeight - 1.0) > 0.001) {
+      alert(`Criteria weights must sum to exactly 1.0 (Currently: ${totalWeight.toFixed(2)})`);
+      return;
+    }
+
+    const payload = {
+      title: hackathonTitle,
+      date: new Date(hackathonDate).toISOString(),
+      description: hackathonDesc,
+      goal: hackathonGoal,
+      status: 'active',
+      criteria,
+      bonus_criteria: bonusCriteria
+    };
+
+    try {
+      const response = await fetch('/api/hackathons', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) throw new Error('Failed to create hackathon');
+      
+      // Real-time local state refresh
+      mutate('/api/hackathons');
+      setIsHackathonModalOpen(false);
+      
+      // Reset form
+      setHackathonTitle('');
+      setHackathonDate('');
+      setHackathonDescription('');
+      setHackathonGoal('');
+      setCriteria(DEFAULT_CRITERIA);
+      setBonusCriteria([]);
+    } catch (err: any) {
+      alert(err.message || 'Operation failed');
+    }
+  };
+
+  const handleCreateProject = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedHackathonId) return;
+
+    const derivedSlug = projTitle
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '');
+
+    const payload = {
+      name: derivedSlug,
+      title: projTitle,
+      url: "",
+      github_url: projGit,
+      team_name: projTeam,
+      document: projDoc || ""
+    };
+
+    try {
+      const response = await fetch(`/api/hackathons/${selectedHackathonId}/projects`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) throw new Error('Failed to add project');
+      
+      setIsProjectModalOpen(false);
+      setProjTitle('');
+      setProjGit('');
+      setProjTeam('');
+      setProjDoc('');
+      alert('Project successfully added to the hackathon!');
+    } catch (err: any) {
+      alert(err.message || 'Operation failed');
+    }
+  };
+
+  // Helper arrays builders
+  const addCriteriaRow = () => {
+    setCriteria([...criteria, { name: '', description: '', weight: 0.1, max_score: 5 }]);
+  };
+
+  const removeCriteriaRow = (index: number) => {
+    setCriteria(criteria.filter((_, i) => i !== index));
+  };
+
+  const addBonusRow = () => {
+    setBonusCriteria([...bonusCriteria, { name: '', description: '', weight: 1.0, max_score: 2 }]);
+  };
+
+  const removeBonusRow = (index: number) => {
+    setBonusCriteria(bonusCriteria.filter((_, i) => i !== index));
+  };
 
   return (
-    <div className="p-4">
-      <h2 className="text-2xl font-bold mb-6">Dashboard</h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {hackathons.map((h) => (
-          <div key={h.id} className="border border-slate-200 rounded-lg p-4 bg-white hover:border-blue-600 transition-colors">
-            <h3 className="text-xl font-semibold mb-2">{h.title}</h3>
-            <p className="text-gray-600 mb-1">Date: {new Date(h.date).toLocaleDateString()}</p>
-            <p className="text-gray-600 mb-1">Status: {h.status}</p>
-            <p className="text-gray-700 mb-4 line-clamp-2">{h.goal}</p>
-            <Link 
-              to={`/hackathons/${h.id}`}
-              className="inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition-colors"
-            >
-              View Projects
-            </Link>
-          </div>
-        ))}
+    <div className="p-6 max-w-7xl mx-auto space-y-8">
+      {/* Header Panel */}
+      <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 bg-white p-6 rounded-2xl border border-slate-100 shadow-xs">
+        <div>
+          <h2 className="text-3xl font-extrabold text-slate-900 tracking-tight">Hackathon Judge Central</h2>
+          <p className="text-slate-500 mt-1">Manage hackathons, configure AI evaluators, and onboard team submissions.</p>
+        </div>
+        <button
+          onClick={() => setIsHackathonModalOpen(true)}
+          className="flex items-center gap-2 bg-gradient-to-r from-blue-600 to-indigo-600 text-white font-semibold px-5 py-3 rounded-xl hover:opacity-95 shadow-md shadow-blue-500/10 transition-all transform hover:-translate-y-0.5 cursor-pointer"
+        >
+          <Plus className="w-5 h-5" />
+          Create Hackathon
+        </button>
       </div>
+
+      {/* Grid of Hackathons */}
+      {isLoading ? (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {[1, 2, 3].map(n => (
+            <div key={n} className="h-64 bg-slate-100 animate-pulse rounded-2xl border border-slate-200"></div>
+          ))}
+        </div>
+      ) : error ? (
+        <div className="p-6 bg-red-50 text-red-600 rounded-xl border border-red-100">Failed to sync hackathon dashboard.</div>
+      ) : !hackathons || hackathons.length === 0 ? (
+        <div className="text-center p-12 bg-white rounded-2xl border border-slate-100 shadow-inner">
+          <ClipboardCheck className="w-12 h-12 text-slate-300 mx-auto mb-4" />
+          <h3 className="text-lg font-semibold text-slate-700">No hackathons onboarded</h3>
+          <p className="text-slate-400 text-sm mt-1 mb-6">Create your first hackathon and configure AI-driven evaluation rubrics.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {hackathons.map((h) => (
+            <div 
+              key={h.id} 
+              className="group bg-white border border-slate-100 rounded-2xl p-6 shadow-xs hover:shadow-md hover:border-blue-500/40 hover:-translate-y-1 transition-all duration-300 flex flex-col justify-between"
+            >
+              <div>
+                <div className="flex justify-between items-center mb-4">
+                  <span className={`text-xs font-semibold px-2.5 py-1 rounded-full capitalize ${
+                    h.status === 'active' ? 'bg-emerald-50 text-green-700 border border-green-100' : 'bg-slate-100 text-slate-600'
+                  }`}>
+                    {h.status}
+                  </span>
+                  <div className="flex items-center gap-1.5 text-slate-400 text-xs">
+                    <Calendar className="w-3.5 h-3.5" />
+                    {new Date(h.date).toLocaleDateString()}
+                  </div>
+                </div>
+
+                <h3 className="text-xl font-bold text-slate-800 group-hover:text-blue-600 transition-colors mb-2">{h.title}</h3>
+                <p className="text-slate-600 text-sm mb-4 line-clamp-3">{h.goal}</p>
+
+                {/* Rubrics Preview pill */}
+                <div className="flex flex-wrap gap-1.5 mb-6">
+                  {h.criteria?.map((c, i) => (
+                    <span key={i} className="text-[10px] font-medium bg-slate-50 text-slate-500 border border-slate-100 px-2 py-0.5 rounded-md">
+                      {c.name} ({Math.round(c.weight * 100)}%)
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex gap-2 pt-4 border-t border-slate-50">
+                <Link 
+                  to={`/hackathons/${h.id}`}
+                  className="flex-1 text-center bg-slate-50 hover:bg-slate-100 text-slate-700 font-semibold px-4 py-2.5 rounded-xl text-xs transition-colors"
+                >
+                  View Projects
+                </Link>
+                <button
+                  onClick={() => {
+                    setSelectedHackathonId(h.id);
+                    setIsProjectModalOpen(true);
+                  }}
+                  className="flex items-center justify-center gap-1 bg-blue-50 hover:bg-blue-100 text-blue-600 font-semibold px-4 py-2.5 rounded-xl text-xs transition-colors cursor-pointer"
+                >
+                  <Plus className="w-3.5 h-3.5" />
+                  Add Project
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* ==================== CREATE HACKATHON DIALOG (GLASSMORPHIC BACKDROP) ==================== */}
+      {isHackathonModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-end">
+          <div className="absolute inset-0 bg-slate-900/40 backdrop-blur-xs" onClick={() => setIsHackathonModalOpen(false)}></div>
+          <div className="relative w-full max-w-2xl h-full bg-white/95 backdrop-blur-md shadow-2xl p-8 flex flex-col justify-between overflow-y-auto border-l border-slate-100">
+            
+            <div className="space-y-6">
+              <div className="flex justify-between items-center border-b border-slate-100 pb-4">
+                <div className="flex items-center gap-2">
+                  <Sparkles className="w-6 h-6 text-indigo-600" />
+                  <h3 className="text-2xl font-black text-slate-800">Add New Hackathon</h3>
+                </div>
+                <button onClick={() => setIsHackathonModalOpen(false)} className="text-slate-400 hover:text-slate-600 rounded-lg p-1.5 hover:bg-slate-50 transition-colors">
+                  <X className="w-6 h-6" />
+                </button>
+              </div>
+
+              <form onSubmit={handleCreateHackathon} className="space-y-5">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-1">
+                    <label className="text-xs font-bold text-slate-500 uppercase tracking-wide">Hackathon Title</label>
+                    <input 
+                      type="text" 
+                      required 
+                      value={hackathonTitle} 
+                      onChange={(e) => setHackathonTitle(e.target.value)} 
+                      placeholder="e.g. Summer Productivity Jam"
+                      className="w-full border border-slate-200 focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20 rounded-xl px-4 py-2.5 text-slate-700 placeholder-slate-400 transition-all text-sm outline-hidden"
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="text-xs font-bold text-slate-500 uppercase tracking-wide">Event Date</label>
+                    <input 
+                      type="date" 
+                      required 
+                      value={hackathonDate} 
+                      onChange={(e) => setHackathonDate(e.target.value)} 
+                      className="w-full border border-slate-200 focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20 rounded-xl px-4 py-2.5 text-slate-700 transition-all text-sm outline-hidden"
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-1">
+                  <label className="text-xs font-bold text-slate-500 uppercase tracking-wide">Global Goal Statement</label>
+                  <input 
+                    type="text" 
+                    required 
+                    value={hackathonGoal} 
+                    onChange={(e) => setHackathonGoal(e.target.value)} 
+                    placeholder="e.g. Build tools that drastically improve developer productivity."
+                    className="w-full border border-slate-200 focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20 rounded-xl px-4 py-2.5 text-slate-700 placeholder-slate-400 transition-all text-sm outline-hidden"
+                  />
+                </div>
+
+                <div className="space-y-1">
+                  <label className="text-xs font-bold text-slate-500 uppercase tracking-wide">Description & Details</label>
+                  <textarea 
+                    rows={2} 
+                    required 
+                    value={hackathonDesc} 
+                    onChange={(e) => setHackathonDescription(e.target.value)} 
+                    placeholder="Provide contextual details and rules about the competition..."
+                    className="w-full border border-slate-200 focus:border-blue-500 focus:ring-1 focus:ring-blue-500/20 rounded-xl px-4 py-2.5 text-slate-700 placeholder-slate-400 transition-all text-sm outline-hidden resize-none"
+                  />
+                </div>
+
+                {/* 🌟 SCORING CRITERIA LIST BUILDER */}
+                <div className="space-y-3 pt-2">
+                  <div className="flex justify-between items-center">
+                    <label className="text-xs font-bold text-indigo-600 uppercase tracking-wide flex items-center gap-1">
+                      <Settings2 className="w-4 h-4" />
+                      Standard Evaluation Rubrics
+                    </label>
+                    <button 
+                      type="button" 
+                      onClick={addCriteriaRow}
+                      className="text-xs font-bold text-blue-600 hover:text-blue-700 hover:underline flex items-center gap-0.5 cursor-pointer"
+                    >
+                      <Plus className="w-3.5 h-3.5" />
+                      Add Criterion
+                    </button>
+                  </div>
+
+                  <div className="max-h-[220px] overflow-y-auto space-y-3 pr-1.5 border border-slate-100 rounded-xl p-3 bg-slate-50/50">
+                    {criteria.map((item, index) => (
+                      <div key={index} className="flex gap-2 items-start bg-white p-3 rounded-lg border border-slate-100 shadow-xs">
+                        <div className="flex-1 space-y-2">
+                          <input 
+                            type="text" 
+                            required 
+                            placeholder="Criterion Name"
+                            value={item.name}
+                            onChange={(e) => {
+                              const copy = [...criteria];
+                              copy[index].name = e.target.value;
+                              setCriteria(copy);
+                            }}
+                            className="w-full border-b border-slate-200 text-xs font-bold focus:border-blue-500 outline-hidden pb-0.5"
+                          />
+                          <input 
+                            type="text" 
+                            required 
+                            placeholder="Scoring guidance reasoning description..."
+                            value={item.description}
+                            onChange={(e) => {
+                              const copy = [...criteria];
+                              copy[index].description = e.target.value;
+                              setCriteria(copy);
+                            }}
+                            className="w-full text-[11px] text-slate-500 border-none outline-hidden focus:ring-0 pb-0"
+                          />
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <div className="w-16">
+                            <span className="text-[9px] text-slate-400 font-bold block mb-0.5">WEIGHT</span>
+                            <input 
+                              type="number" 
+                              required 
+                              step="0.01" 
+                              min="0" 
+                              max="1" 
+                              value={item.weight}
+                              onChange={(e) => {
+                                const copy = [...criteria];
+                                copy[index].weight = Number(e.target.value);
+                                setCriteria(copy);
+                              }}
+                              className="w-full border border-slate-200 rounded-md p-1 text-xs text-center font-semibold"
+                            />
+                          </div>
+                          <div className="w-12">
+                            <span className="text-[9px] text-slate-400 font-bold block mb-0.5">MAX</span>
+                            <input 
+                              type="number" 
+                              required 
+                              min="1" 
+                              value={item.max_score}
+                              onChange={(e) => {
+                                const copy = [...criteria];
+                                copy[index].max_score = Number(e.target.value);
+                                setCriteria(copy);
+                              }}
+                              className="w-full border border-slate-200 rounded-md p-1 text-xs text-center"
+                            />
+                          </div>
+                          <button 
+                            type="button" 
+                            onClick={() => removeCriteriaRow(index)}
+                            className="text-slate-300 hover:text-red-500 self-end mb-1 transition-colors"
+                          >
+                            <Trash className="w-4 h-4" />
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* Criteria Weights Total Indicator */}
+                  <div className="flex justify-between items-center text-xs px-2">
+                    <span className="font-semibold text-slate-500">Weight allocation checker:</span>
+                    <span className={`font-bold flex items-center gap-1 ${
+                      Math.abs(criteria.reduce((s, c) => s + c.weight, 0) - 1.0) < 0.001 
+                        ? 'text-emerald-600' 
+                        : 'text-amber-500'
+                    }`}>
+                      {Math.abs(criteria.reduce((s, c) => s + c.weight, 0) - 1.0) < 0.001 ? (
+                        <Check className="w-3.5 h-3.5" />
+                      ) : null}
+                      Total: {criteria.reduce((sum, c) => sum + c.weight, 0).toFixed(2)} / 1.00
+                    </span>
+                  </div>
+                </div>
+
+                {/* 🚀 BONUS CRITERIA BUILDER */}
+                <div className="space-y-3">
+                  <div className="flex justify-between items-center">
+                    <label className="text-xs font-bold text-amber-600 uppercase tracking-wide flex items-center gap-1">
+                      <Award className="w-4 h-4" />
+                      Bonus Metrics (Optional)
+                    </label>
+                    <button 
+                      type="button" 
+                      onClick={addBonusRow}
+                      className="text-xs font-bold text-blue-600 hover:text-blue-700 hover:underline flex items-center gap-0.5 cursor-pointer"
+                    >
+                      <Plus className="w-3.5 h-3.5" />
+                      Add Bonus
+                    </button>
+                  </div>
+
+                  {bonusCriteria.length > 0 && (
+                    <div className="space-y-2 max-h-[140px] overflow-y-auto border border-slate-100 rounded-xl p-3 bg-slate-50/50">
+                      {bonusCriteria.map((item, index) => (
+                        <div key={index} className="flex gap-2 items-start bg-white p-2.5 rounded-lg border border-slate-100 shadow-xs">
+                          <div className="flex-1 space-y-1">
+                            <input 
+                              type="text" 
+                              required 
+                              placeholder="Bonus Name"
+                              value={item.name}
+                              onChange={(e) => {
+                                const copy = [...bonusCriteria];
+                                copy[index].name = e.target.value;
+                                setBonusCriteria(copy);
+                              }}
+                              className="w-full border-b border-slate-200 text-xs font-bold outline-hidden pb-0.5"
+                            />
+                            <input 
+                              type="text" 
+                              required 
+                              placeholder="Reasoning details..."
+                              value={item.description}
+                              onChange={(e) => {
+                                const copy = [...bonusCriteria];
+                                copy[index].description = e.target.value;
+                                setBonusCriteria(copy);
+                              }}
+                              className="w-full text-[10px] text-slate-500 border-none outline-hidden focus:ring-0"
+                            />
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <div className="w-16">
+                              <input 
+                                type="number" 
+                                required 
+                                value={item.max_score}
+                                onChange={(e) => {
+                                  const copy = [...bonusCriteria];
+                                  copy[index].max_score = Number(e.target.value);
+                                  setBonusCriteria(copy);
+                                }}
+                                className="w-full border border-slate-200 rounded-md p-1 text-xs text-center"
+                              />
+                            </div>
+                            <button type="button" onClick={() => removeBonusRow(index)} className="text-slate-300 hover:text-red-500 transition-colors">
+                              <Trash className="w-4 h-4" />
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                <div className="pt-6 border-t border-slate-100 flex justify-end gap-3">
+                  <button 
+                    type="button" 
+                    onClick={() => setIsHackathonModalOpen(false)}
+                    className="border border-slate-200 hover:bg-slate-50 text-slate-600 font-semibold px-4 py-2.5 rounded-xl text-sm transition-colors cursor-pointer"
+                  >
+                    Cancel
+                  </button>
+                  <button 
+                    type="submit"
+                    className="bg-gradient-to-r from-blue-600 to-indigo-600 hover:opacity-95 text-white font-semibold px-5 py-2.5 rounded-xl text-sm transition-all shadow-md shadow-blue-500/10 cursor-pointer"
+                  >
+                    Save & Initialize
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ==================== CREATE PROJECT DIALOG ==================== */}
+      {isProjectModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div 
+            className="absolute inset-0 bg-slate-900 bg-opacity-60" 
+            onClick={() => setIsProjectModalOpen(false)}
+          ></div>
+          
+          <div className="relative w-full max-w-lg bg-white rounded-xl shadow-2xl border border-slate-300 overflow-hidden z-10 flex flex-col">
+            {/* Header */}
+            <div className="bg-slate-950 px-6 py-4 flex justify-between items-center text-white">
+              <div className="flex items-center gap-2">
+                <Plus className="w-5 h-5 text-blue-400" />
+                <h3 className="text-lg font-bold tracking-tight">Add Team Project Submission</h3>
+              </div>
+              <button 
+                onClick={() => setIsProjectModalOpen(false)} 
+                className="text-slate-400 hover:text-white rounded-lg p-1.5 hover:bg-white/10 transition-colors"
+                aria-label="Close modal"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* Form */}
+            <form onSubmit={handleCreateProject} className="p-6 space-y-5 bg-white">
+              <div className="space-y-1">
+                <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider">
+                  Project Name <span className="text-red-500">*</span>
+                </label>
+                <input 
+                  type="text" 
+                  required 
+                  value={projTitle} 
+                  onChange={(e) => setProjTitle(e.target.value)} 
+                  placeholder="e.g. Daybreak Planner"
+                  className="w-full bg-white border border-slate-300 focus:border-blue-600 focus:ring-1 focus:ring-blue-600 rounded-lg px-3 py-2 text-sm text-slate-950 placeholder-slate-400 font-medium transition-all"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider">
+                  Team Name <span className="text-red-500">*</span>
+                </label>
+                <input 
+                  type="text" 
+                  required 
+                  value={projTeam} 
+                  onChange={(e) => setProjTeam(e.target.value)} 
+                  placeholder="e.g. Team Daybreak"
+                  className="w-full bg-white border border-slate-300 focus:border-blue-600 focus:ring-1 focus:ring-blue-600 rounded-lg px-3 py-2 text-sm text-slate-950 placeholder-slate-400 font-medium transition-all"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider">
+                  GitHub URL <span className="text-red-500">*</span>
+                </label>
+                <input 
+                  type="url" 
+                  required 
+                  value={projGit} 
+                  onChange={(e) => setProjGit(e.target.value)} 
+                  placeholder="https://github.com/your-username/your-repo"
+                  className="w-full bg-white border border-slate-300 focus:border-blue-600 focus:ring-1 focus:ring-blue-600 rounded-lg px-3 py-2 text-sm text-slate-950 placeholder-slate-400 font-medium transition-all"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider">
+                  Submission Document / Pitch details <span className="text-slate-400 font-normal">(Optional)</span>
+                </label>
+                <textarea 
+                  rows={3} 
+                  value={projDoc} 
+                  onChange={(e) => setProjDoc(e.target.value)} 
+                  placeholder="Describe your project, features, technologies used, or pitch ideas..."
+                  className="w-full bg-white border border-slate-300 focus:border-blue-600 focus:ring-1 focus:ring-blue-600 rounded-lg px-3 py-2 text-sm text-slate-950 placeholder-slate-400 font-medium transition-all resize-none"
+                />
+              </div>
+
+              {/* Action Buttons */}
+              <div className="pt-4 border-t border-slate-100 flex justify-end gap-2 bg-white">
+                <button 
+                  type="button" 
+                  onClick={() => setIsProjectModalOpen(false)}
+                  className="border border-slate-300 hover:bg-slate-50 text-slate-600 font-semibold px-4 py-2 rounded-lg text-xs"
+                >
+                  Cancel
+                </button>
+                <button 
+                  type="submit"
+                  className="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2 rounded-lg text-xs transition-colors shadow-sm"
+                >
+                  Submit Project
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/Dashboard.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/Dashboard.tsx
@@ -514,7 +514,7 @@ export default function Dashboard() {
       {isProjectModalOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div 
-            className="absolute inset-0 bg-slate-900 bg-opacity-60" 
+            className="absolute inset-0 bg-slate-900/60 backdrop-blur-xs" 
             onClick={() => setIsProjectModalOpen(false)}
           ></div>
           

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/Dashboard.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/Dashboard.tsx
@@ -30,9 +30,57 @@ interface CriterionInput {
 }
 
 const DEFAULT_CRITERIA: CriterionInput[] = [
-  { name: 'Innovation & Originality', description: 'How unique and creative is the solution?', weight: 0.3, max_score: 5 },
-  { name: 'Technical Execution', description: 'Code quality and technical execution completeness.', weight: 0.4, max_score: 5 },
-  { name: 'User Experience (UX/UI)', description: 'Minimalist design for flow-state productivity.', weight: 0.3, max_score: 5 }
+  {
+    name: 'Innovation & Originality',
+    description: 'How unique and original is the productivity tool?\n\n**Low (1-2):** The project is essentially a "Hello World" of productivity (e.g., a basic CRUD to-do list with no unique features).\n**High (4-5):** The team identified a unique bottleneck—like "context switching" or "decision fatigue"—and built a tool specifically to kill that problem.',
+    weight: 0.2,
+    max_score: 5
+  },
+  {
+    name: 'Theme Alignment (Impact)',
+    description: 'Does the app actually save time or remove friction?\n\n**Low (1-2):** The app might be cool, but it doesn\'t actually make the user more efficient.\n**High (4-5):** Does the app actually save time? Does it remove friction? A 5/5 project makes the judges want to start using the app immediately for their own work.',
+    weight: 0.3,
+    max_score: 5
+  },
+  {
+    name: 'Technical Execution',
+    description: 'Quality of implementation and technical complexity.\n\n**Low (1-2):** Code is messy, or the "app" is just a series of static HTML pages with no logic.\n**High (4-5):** The team integrated complex elements (e.g., AI APIs, browser extensions, real-time sync, or advanced data visualization) successfully within the hackathon timeframe.',
+    weight: 0.2,
+    max_score: 5
+  },
+  {
+    name: 'User Experience (UX/UI)',
+    description: 'Design for focus, minimal distractions, and clear feedback.\n\n**Low (1-2):** Buttons don\'t work, text is unreadable, or the workflow is frustrating.\n**High (4-5):** For productivity tools, **less is more**. Points are awarded for "Flow State" design—minimal distractions, keyboard shortcuts, and clear feedback.',
+    weight: 0.1,
+    max_score: 5
+  },
+  {
+    name: 'Pitch & Demo',
+    description: 'Quality of the presentation and live demonstration.\n\n**Low (1-2):** The team spent too much time on the technical stack and forgot to show the actual product.\n**High (4-5):** The team clearly demonstrated a "use case." They showed exactly how a user\'s life is better after using their tool.',
+    weight: 0.2,
+    max_score: 5
+  }
+];
+
+const DEFAULT_BONUS_CRITERIA: CriterionInput[] = [
+  {
+    name: 'Clean Code',
+    description: 'Repository is well-documented with a clear README.',
+    weight: 0.1,
+    max_score: 2
+  },
+  {
+    name: 'Accessibility',
+    description: 'Project considers screen readers, high contrast, or keyboard-only navigation.',
+    weight: 0.05,
+    max_score: 1
+  },
+  {
+    name: 'Wow Factor',
+    description: 'A specific feature that made the judges say "Wait, how did they build that in 24 hours?"',
+    weight: 0.1,
+    max_score: 2
+  }
 ];
 
 export default function Dashboard() {
@@ -43,6 +91,8 @@ export default function Dashboard() {
   const [isHackathonModalOpen, setIsHackathonModalOpen] = useState(false);
   const [isProjectModalOpen, setIsProjectModalOpen] = useState(false);
   const [selectedHackathonId, setSelectedHackathonId] = useState<string | null>(null);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [hackathonToDelete, setHackathonToDelete] = useState<string | null>(null);
 
   // New Hackathon Form Fields
   const [hackathonTitle, setHackathonTitle] = useState('');
@@ -50,7 +100,7 @@ export default function Dashboard() {
   const [hackathonDesc, setHackathonDescription] = useState('');
   const [hackathonGoal, setHackathonGoal] = useState('');
   const [criteria, setCriteria] = useState<CriterionInput[]>(DEFAULT_CRITERIA);
-  const [bonusCriteria, setBonusCriteria] = useState<CriterionInput[]>([]);
+  const [bonusCriteria, setBonusCriteria] = useState<CriterionInput[]>(DEFAULT_BONUS_CRITERIA);
 
   // New Project Form Fields
   const [projTitle, setProjTitle] = useState('');
@@ -97,7 +147,7 @@ export default function Dashboard() {
       setHackathonDescription('');
       setHackathonGoal('');
       setCriteria(DEFAULT_CRITERIA);
-      setBonusCriteria([]);
+      setBonusCriteria(DEFAULT_BONUS_CRITERIA);
     } catch (err: any) {
       alert(err.message || 'Operation failed');
     }
@@ -141,6 +191,23 @@ export default function Dashboard() {
     }
   };
 
+  const handleDeleteHackathon = async () => {
+    if (!hackathonToDelete) return;
+    try {
+      const response = await fetch(`/api/hackathons/${hackathonToDelete}`, {
+        method: 'DELETE'
+      });
+      if (!response.ok) throw new Error('Failed to delete hackathon');
+      
+      // Refresh SWR caches
+      mutate('/api/hackathons');
+      setIsDeleteModalOpen(false);
+      setHackathonToDelete(null);
+    } catch (err: any) {
+      alert(err.message || 'An error occurred while deleting');
+    }
+  };
+
   // Helper arrays builders
   const addCriteriaRow = () => {
     setCriteria([...criteria, { name: '', description: '', weight: 0.1, max_score: 5 }]);
@@ -177,8 +244,8 @@ export default function Dashboard() {
 
       {/* Grid of Hackathons */}
       {isLoading ? (
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {[1, 2, 3].map(n => (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {[1, 2].map(n => (
             <div key={n} className="h-64 bg-slate-100 animate-pulse rounded-2xl border border-slate-200"></div>
           ))}
         </div>
@@ -191,7 +258,7 @@ export default function Dashboard() {
           <p className="text-slate-400 text-sm mt-1 mb-6">Create your first hackathon and configure AI-driven evaluation rubrics.</p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {hackathons.map((h) => (
             <div 
               key={h.id} 
@@ -235,10 +302,20 @@ export default function Dashboard() {
                     setSelectedHackathonId(h.id);
                     setIsProjectModalOpen(true);
                   }}
-                  className="flex items-center justify-center gap-1 bg-blue-50 hover:bg-blue-100 text-blue-600 font-semibold px-4 py-2.5 rounded-xl text-xs transition-colors cursor-pointer"
+                  className="flex-1 flex items-center justify-center gap-1 bg-blue-50 hover:bg-blue-100 text-blue-600 font-semibold px-4 py-2.5 rounded-xl text-xs transition-colors cursor-pointer"
                 >
                   <Plus className="w-3.5 h-3.5" />
                   Add Project
+                </button>
+                <button
+                  onClick={() => {
+                    setHackathonToDelete(h.id);
+                    setIsDeleteModalOpen(true);
+                  }}
+                  className="flex-1 flex items-center justify-center gap-1 bg-red-50 hover:bg-red-100 text-red-600 font-semibold px-4 py-2.5 rounded-xl text-xs transition-colors cursor-pointer"
+                >
+                  <Trash className="w-3.5 h-3.5" />
+                  Delete
                 </button>
               </div>
             </div>
@@ -519,7 +596,7 @@ export default function Dashboard() {
             onClick={() => setIsProjectModalOpen(false)}
           ></div>
           
-          <div className="relative w-full max-w-lg bg-white rounded-xl shadow-2xl border border-slate-300 overflow-hidden z-10 flex flex-col">
+          <div className="relative w-full max-w-[512px] bg-white rounded-xl shadow-2xl border border-slate-300 overflow-hidden z-10 flex flex-col">
             {/* Header */}
             <div className="bg-slate-950 px-6 py-4 flex justify-between items-center text-white">
               <div className="flex items-center gap-2">
@@ -609,6 +686,59 @@ export default function Dashboard() {
                 </button>
               </div>
             </form>
+          </div>
+        </div>,
+        document.body
+      )}
+
+      {/* ==================== DELETE HACKATHON CONFIRMATION DIALOG ==================== */}
+      {isDeleteModalOpen && createPortal(
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div 
+            className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" 
+            onClick={() => setIsDeleteModalOpen(false)}
+          ></div>
+          
+          <div className="relative w-full max-w-[450px] bg-white rounded-xl shadow-2xl border border-slate-300 overflow-hidden z-10 flex flex-col">
+            {/* Header */}
+            <div className="bg-red-600 px-6 py-4 flex justify-between items-center text-white">
+              <div className="flex items-center gap-2">
+                <Trash className="w-5 h-5 text-white" />
+                <h3 className="text-lg font-bold tracking-tight">Delete Hackathon</h3>
+              </div>
+              <button 
+                onClick={() => setIsDeleteModalOpen(false)} 
+                className="text-white/80 hover:text-white rounded-lg p-1.5 hover:bg-white/10 transition-colors"
+                aria-label="Close modal"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* Content */}
+            <div className="p-6 bg-white space-y-4">
+              <p className="text-slate-600 text-sm leading-relaxed">
+                Are you sure you want to delete this hackathon? This action is <strong className="text-red-600 font-bold">permanent</strong> and will delete all associated projects and evaluation results from the database.
+              </p>
+
+              {/* Action Buttons */}
+              <div className="pt-4 border-t border-slate-100 flex justify-end gap-2 bg-white">
+                <button 
+                  type="button" 
+                  onClick={() => setIsDeleteModalOpen(false)}
+                  className="border border-slate-300 hover:bg-slate-50 text-slate-600 font-semibold px-4 py-2 rounded-lg text-xs cursor-pointer"
+                >
+                  Cancel
+                </button>
+                <button 
+                  type="button"
+                  onClick={handleDeleteHackathon}
+                  className="bg-red-600 hover:bg-red-700 text-white font-semibold px-4 py-2 rounded-lg text-xs transition-colors shadow-sm cursor-pointer"
+                >
+                  Delete Permanently
+                </button>
+              </div>
+            </div>
           </div>
         </div>,
         document.body

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/Dashboard.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/Dashboard.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import useSWR, { useSWRConfig } from 'swr';
 import { Link } from 'react-router-dom';
 import { fetcher } from '../utils/fetcher';
@@ -511,10 +512,10 @@ export default function Dashboard() {
       )}
 
       {/* ==================== CREATE PROJECT DIALOG ==================== */}
-      {isProjectModalOpen && (
+      {isProjectModalOpen && createPortal(
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div 
-            className="absolute inset-0 bg-slate-900/60 backdrop-blur-xs" 
+            className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" 
             onClick={() => setIsProjectModalOpen(false)}
           ></div>
           
@@ -609,7 +610,8 @@ export default function Dashboard() {
               </div>
             </form>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/HackathonDetail.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/HackathonDetail.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import useSWR from 'swr';
 import { useParams, Link } from 'react-router-dom';
 import { fetcher } from '../utils/fetcher';
@@ -283,10 +284,10 @@ export default function HackathonDetail() {
       )}
 
       {/* ==================== CREATE PROJECT DIALOG ==================== */}
-      {isProjectModalOpen && (
+      {isProjectModalOpen && createPortal(
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div 
-            className="absolute inset-0 bg-slate-900/60 backdrop-blur-xs" 
+            className="absolute inset-0 bg-slate-900/60 backdrop-blur-sm" 
             onClick={() => setIsProjectModalOpen(false)}
           ></div>
           
@@ -381,7 +382,8 @@ export default function HackathonDetail() {
               </div>
             </form>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/HackathonDetail.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/HackathonDetail.tsx
@@ -19,6 +19,7 @@ import useSWR from 'swr';
 import { useParams, Link } from 'react-router-dom';
 import { fetcher } from '../utils/fetcher';
 import type { Project, Evaluation, Hackathon } from '../types/models';
+import { Plus, X } from 'lucide-react';
 
 function ProjectCard({ project, evaluations, mutateEvaluations }: { project: Project, evaluations?: Evaluation[], mutateEvaluations: () => void }) {
   const [isTriggeringAgent, setIsTriggeringAgent] = useState(false);
@@ -98,7 +99,57 @@ export default function HackathonDetail() {
   const [activeTab, setActiveTab] = useState<'projects' | 'criteria'>('projects');
   
   const { data: hackathon, error: hackathonError, isLoading: isHackathonLoading } = useSWR<Hackathon>(id ? `/api/hackathons/${id}` : null, fetcher);
-  const { data: projects, error: projectsError, isLoading: isProjectsLoading } = useSWR<Project[]>(id ? `/api/hackathons/${id}/projects` : null, fetcher);
+  const { data: projects, error: projectsError, isLoading: isProjectsLoading, mutate: mutateProjects } = useSWR<Project[]>(id ? `/api/hackathons/${id}/projects` : null, fetcher);
+
+  // New Project Form Fields
+  const [isProjectModalOpen, setIsProjectModalOpen] = useState(false);
+  const [projTitle, setProjTitle] = useState('');
+  const [projGit, setProjGit] = useState('');
+  const [projTeam, setProjTeam] = useState('');
+  const [projDoc, setProjDoc] = useState('');
+
+  const handleCreateProject = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+
+    const derivedSlug = projTitle
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '');
+
+    const payload = {
+      name: derivedSlug,
+      title: projTitle,
+      url: "",
+      github_url: projGit,
+      team_name: projTeam,
+      document: projDoc || ""
+    };
+
+    try {
+      const response = await fetch(`/api/hackathons/${id}/projects`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.error || 'Failed to add project');
+      }
+      
+      setIsProjectModalOpen(false);
+      setProjTitle('');
+      setProjGit('');
+      setProjTeam('');
+      setProjDoc('');
+      
+      await mutateProjects();
+      alert('Project successfully added to the hackathon!');
+    } catch (err: any) {
+      alert(err.message || 'Operation failed');
+    }
+  };
 
   const { data: evaluationsData, mutate: mutateEvaluations } = useSWR<Evaluation[][]>(
     projects && projects.length > 0 ? `hackathon-${id}-evaluations` : null,
@@ -136,8 +187,8 @@ export default function HackathonDetail() {
         )}
       </div>
 
-      <div className="mb-6 border-b border-gray-200">
-        <nav className="-mb-px flex space-x-8">
+      <div className="mb-6 border-b border-gray-200 flex flex-col sm:flex-row justify-between sm:items-center gap-4">
+        <nav className="-mb-px flex space-x-8 overflow-x-auto">
           <button
             onClick={() => setActiveTab('projects')}
             className={`${
@@ -159,6 +210,15 @@ export default function HackathonDetail() {
             Judging Criteria
           </button>
         </nav>
+        {activeTab === 'projects' && (
+          <button
+            onClick={() => setIsProjectModalOpen(true)}
+            className="flex items-center justify-center gap-1.5 bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2 rounded-lg text-xs transition-colors shadow-sm cursor-pointer mb-2 shrink-0 self-start sm:self-auto"
+          >
+            <Plus className="w-4 h-4" />
+            Add Project
+          </button>
+        )}
       </div>
 
       {activeTab === 'projects' && (
@@ -190,9 +250,9 @@ export default function HackathonDetail() {
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {hackathon.criteria.map((c, idx) => (
                   <div key={idx} className="bg-white p-4 border rounded-lg shadow-sm">
-                    <div className="flex justify-between items-start mb-2">
+                    <div className="flex flex-col sm:flex-row justify-between sm:items-start gap-2 mb-2">
                       <h4 className="font-bold text-lg text-slate-800">{c.name}</h4>
-                      <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full font-medium">Weight: {c.weight} &middot; Max: {c.max_score}</span>
+                      <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full font-medium shrink-0 self-start sm:self-auto">Weight: {c.weight} &middot; Max: {c.max_score}</span>
                     </div>
                     <p className="text-gray-600 text-sm">{c.description}</p>
                   </div>
@@ -209,9 +269,9 @@ export default function HackathonDetail() {
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {hackathon.bonus_criteria.map((c, idx) => (
                   <div key={idx} className="bg-purple-50 p-4 border border-purple-100 rounded-lg shadow-sm">
-                    <div className="flex justify-between items-start mb-2">
+                    <div className="flex flex-col sm:flex-row justify-between sm:items-start gap-2 mb-2">
                       <h4 className="font-bold text-lg text-purple-900">{c.name}</h4>
-                      <span className="bg-purple-200 text-purple-900 text-xs px-2 py-1 rounded-full font-medium">Weight: {c.weight} &middot; Max: {c.max_score}</span>
+                      <span className="bg-purple-200 text-purple-900 text-xs px-2 py-1 rounded-full font-medium shrink-0 self-start sm:self-auto">Weight: {c.weight} &middot; Max: {c.max_score}</span>
                     </div>
                     <p className="text-purple-700 text-sm">{c.description}</p>
                   </div>
@@ -219,6 +279,108 @@ export default function HackathonDetail() {
               </div>
             )}
           </section>
+        </div>
+      )}
+
+      {/* ==================== CREATE PROJECT DIALOG ==================== */}
+      {isProjectModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div 
+            className="absolute inset-0 bg-slate-900 bg-opacity-60" 
+            onClick={() => setIsProjectModalOpen(false)}
+          ></div>
+          
+          <div className="relative w-full max-w-lg bg-white rounded-xl shadow-2xl border border-slate-300 overflow-hidden z-10 flex flex-col">
+            {/* Header */}
+            <div className="bg-slate-950 px-6 py-4 flex justify-between items-center text-white">
+              <div className="flex items-center gap-2">
+                <Plus className="w-5 h-5 text-blue-400" />
+                <h3 className="text-lg font-bold tracking-tight">Add Team Project Submission</h3>
+              </div>
+              <button 
+                onClick={() => setIsProjectModalOpen(false)} 
+                className="text-slate-400 hover:text-white rounded-lg p-1.5 hover:bg-white/10 transition-colors"
+                aria-label="Close modal"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* Form */}
+            <form onSubmit={handleCreateProject} className="p-6 space-y-5 bg-white">
+              <div className="space-y-1">
+                <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider">
+                  Project Name <span className="text-red-500">*</span>
+                </label>
+                <input 
+                  type="text" 
+                  required 
+                  value={projTitle} 
+                  onChange={(e) => setProjTitle(e.target.value)} 
+                  placeholder="e.g. Daybreak Planner"
+                  className="w-full bg-white border border-slate-300 focus:border-blue-600 focus:ring-1 focus:ring-blue-600 rounded-lg px-3 py-2 text-sm text-slate-950 placeholder-slate-400 font-medium transition-all"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider">
+                  Team Name <span className="text-red-500">*</span>
+                </label>
+                <input 
+                  type="text" 
+                  required 
+                  value={projTeam} 
+                  onChange={(e) => setProjTeam(e.target.value)} 
+                  placeholder="e.g. Team Daybreak"
+                  className="w-full bg-white border border-slate-300 focus:border-blue-600 focus:ring-1 focus:ring-blue-600 rounded-lg px-3 py-2 text-sm text-slate-950 placeholder-slate-400 font-medium transition-all"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider">
+                  GitHub URL <span className="text-red-500">*</span>
+                </label>
+                <input 
+                  type="url" 
+                  required 
+                  value={projGit} 
+                  onChange={(e) => setProjGit(e.target.value)} 
+                  placeholder="https://github.com/your-username/your-repo"
+                  className="w-full bg-white border border-slate-300 focus:border-blue-600 focus:ring-1 focus:ring-blue-600 rounded-lg px-3 py-2 text-sm text-slate-950 placeholder-slate-400 font-medium transition-all"
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="block text-xs font-bold text-slate-700 uppercase tracking-wider">
+                  Submission Document / Pitch details <span className="text-slate-400 font-normal">(Optional)</span>
+                </label>
+                <textarea 
+                  rows={3} 
+                  value={projDoc} 
+                  onChange={(e) => setProjDoc(e.target.value)} 
+                  placeholder="Describe your project, features, technologies used, or pitch ideas..."
+                  className="w-full bg-white border border-slate-300 focus:border-blue-600 focus:ring-1 focus:ring-blue-600 rounded-lg px-3 py-2 text-sm text-slate-950 placeholder-slate-400 font-medium transition-all resize-none"
+                />
+              </div>
+
+              {/* Action Buttons */}
+              <div className="pt-4 border-t border-slate-100 flex justify-end gap-2 bg-white">
+                <button 
+                  type="button" 
+                  onClick={() => setIsProjectModalOpen(false)}
+                  className="border border-slate-300 hover:bg-slate-50 text-slate-600 font-semibold px-4 py-2 rounded-lg text-xs"
+                >
+                  Cancel
+                </button>
+                <button 
+                  type="submit"
+                  className="bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2 rounded-lg text-xs transition-colors shadow-sm"
+                >
+                  Submit Project
+                </button>
+              </div>
+            </form>
+          </div>
         </div>
       )}
     </div>

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/HackathonDetail.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/HackathonDetail.tsx
@@ -286,7 +286,7 @@ export default function HackathonDetail() {
       {isProjectModalOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div 
-            className="absolute inset-0 bg-slate-900 bg-opacity-60" 
+            className="absolute inset-0 bg-slate-900/60 backdrop-blur-xs" 
             onClick={() => setIsProjectModalOpen(false)}
           ></div>
           

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/HackathonDetail.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/HackathonDetail.tsx
@@ -291,7 +291,7 @@ export default function HackathonDetail() {
             onClick={() => setIsProjectModalOpen(false)}
           ></div>
           
-          <div className="relative w-full max-w-lg bg-white rounded-xl shadow-2xl border border-slate-300 overflow-hidden z-10 flex flex-col">
+          <div className="relative w-full max-w-[512px] bg-white rounded-xl shadow-2xl border border-slate-300 overflow-hidden z-10 flex flex-col">
             {/* Header */}
             <div className="bg-slate-950 px-6 py-4 flex justify-between items-center text-white">
               <div className="flex items-center gap-2">

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/ProjectDetail.tsx
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/src/pages/ProjectDetail.tsx
@@ -169,9 +169,9 @@ export default function ProjectDetail() {
 
                       return (
                         <div key={idx} className="bg-gray-50 p-4 rounded-lg border border-gray-100">
-                          <div className="flex justify-between items-center mb-2 pb-2 border-b border-gray-200">
+                          <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-3 mb-2 pb-2 border-b border-gray-200">
                             <span className="font-bold text-slate-700 text-lg">{c.name}</span>
-                            <div className="flex items-center gap-4">
+                            <div className="flex items-center gap-4 shrink-0">
                               <div className="text-right">
                                 <span className="text-[10px] text-gray-400 uppercase font-bold block leading-none mb-1">Score</span>
                                 <span className="font-black text-blue-600 text-lg">{typeof c.score === 'number' ? c.score.toFixed(2) : 'N/A'}</span>

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/vite.config.ts
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/frontend/vite.config.ts
@@ -21,8 +21,8 @@ import tailwindcss from '@tailwindcss/vite'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
-    react(),
     tailwindcss(),
+    react(),
   ],
   server: {
     proxy: {

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/setup-env.sh
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/setup-env.sh
@@ -86,6 +86,7 @@ if command -v git &> /dev/null && git rev-parse --short HEAD &> /dev/null; then
   if [ -n "$(git status --porcelain)" ]; then
     echo -e "${YELLOW}⚠️  Git repository has uncommitted changes (dirty state).${NC}"
     export COMMIT_SHA="dirty-$(date +%s)"
+    export COMMIT_SHA="latest"
   else
     export COMMIT_SHA=$(git rev-parse --short HEAD)
   fi

--- a/codelabs/ai-toolkit-lab-2/hackathon-judge/setup-env.sh
+++ b/codelabs/ai-toolkit-lab-2/hackathon-judge/setup-env.sh
@@ -86,7 +86,6 @@ if command -v git &> /dev/null && git rev-parse --short HEAD &> /dev/null; then
   if [ -n "$(git status --porcelain)" ]; then
     echo -e "${YELLOW}⚠️  Git repository has uncommitted changes (dirty state).${NC}"
     export COMMIT_SHA="dirty-$(date +%s)"
-    export COMMIT_SHA="latest"
   else
     export COMMIT_SHA=$(git rev-parse --short HEAD)
   fi


### PR DESCRIPTION
### Summary of Changes
  
    This Pull Request implements the complete **Delete Hackathon** feature, including backend database persistence (supporting both Memory Repository and BigQuery layers), visual layout          
  adjustments for dashboard action buttons, and comprehensive unit test coverage.
  
    #### 1. Backend Persistence & Deletion REST API
    * Implemented `DELETE /api/hackathons/:id` across repository, service, and handler layers.
    * Added `Delete(id string)` repository methods for both `MemoryRepo` (thread-safe locking) and `BigQueryRepo`.
    * Orchestrated domain routing and service-level delete flows.
  
    #### 2. Frontend Delete Flow & Visual Polish
    * Implemented SWR cache revalidation (`mutate('/api/hackathons')`) on successful delete.
    * Integrated a high-fidelity **Delete Confirmation Modal** in `Dashboard.tsx` via React Portal to prevent layout warping.
    * Adjusted action button widths to use equal flex sizing (`flex-1`) and configured the tile grid to display up to 2 columns on medium/large screens to prevent button text wrapping.           
  
    #### 3. Complete Unit Test Coverage
    * **Backend**:
      * Added service-layer unit tests for `DeleteHackathon` (covering successful delete and not-found cases).
      * Added API handler-layer unit tests for `DELETE /api/hackathons/:id` (covering status validation and responses).
    * **Frontend**:
      * Fixed pre-existing SWR testing bugs by properly mocking named SWR exports (`useSWRConfig`).
      * Updated outdated loading and error string expectations to match modern animated pulse skeletons.
      * Added complete React testing-library tests for clicking the card's delete button, verifying the portal modal overlay, confirming deletion, and asserting on fetch payload.